### PR TITLE
Fixes #131: Build goaws for amd64 rather than arm

### DIFF
--- a/makefile.txt
+++ b/makefile.txt
@@ -19,7 +19,7 @@ git-release:
 	curl --data $(APIJSON) https://api.github.com/repos/p4tin/goaws/releases?access_token=$(GITHUB_API_KEY)
 
 linux:
-	GOOS=linux GOARCH=arm GOARM=5 go build -o goaws_linux_amd64  app/cmd/goaws.go
+	GOOS=linux GOARCH=amd64 go build -o goaws_linux_amd64  app/cmd/goaws.go
 
 docker-release: linux
 	docker build -t pafortin/goaws .


### PR DESCRIPTION
The amd64 instruction set is compatible with the vast majority of CPUs.
Let's build amd64 executables rather than arm.