### PR TITLE
add queue existence check to SendMessageBatch and some other fixes. 

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -165,6 +165,10 @@ func SendMessageBatch(w http.ResponseWriter, req *http.Request) {
 	for k, v := range req.Form {
 		keySegments := strings.Split(k, ".")
 		if keySegments[0] == "SendMessageBatchRequestEntry" {
+			if len(keySegments) < 3 {
+				createErrorResponse(w, req, "EmptyBatchRequest")
+				return
+			}
 			keyIndex, err := strconv.Atoi(keySegments[1])
 
 			if err != nil {

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -305,10 +305,10 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 				app.SyncQueues.Lock() // Lock the Queues
 				uuid, _ := common.NewUUID()
 
-				msg := app.SyncQueues.Queues[queueName].Messages[i]
+				msg := &app.SyncQueues.Queues[queueName].Messages[i]
 				msg.ReceiptHandle = msg.Uuid + "#" + uuid
 				msg.ReceiptTime = time.Now()
-				message = append(message, getMessageResult(&msg))
+				message = append(message, getMessageResult(msg))
 
 				app.SyncQueues.Unlock() // Unlock the Queues
 				numMsg++

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -155,6 +155,11 @@ func SendMessageBatch(w http.ResponseWriter, req *http.Request) {
 		queueName = uriSegments[len(uriSegments)-1]
 	}
 
+	if _, ok := app.SyncQueues.Queues[queueName]; !ok {
+		createErrorResponse(w, req, "QueueNotFound")
+		return
+	}
+
 	sendEntries := []SendEntry{}
 
 	for k, v := range req.Form {

--- a/app/gosqs/gosqs_test.go
+++ b/app/gosqs/gosqs_test.go
@@ -229,6 +229,24 @@ func TestSendMessageBatch_POST_NoEntry(t *testing.T) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)
 	}
+
+	req, _ = http.NewRequest("POST", "/", nil)
+	form.Add("SendMessageBatchRequestEntry", "")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+
+	if !strings.Contains(rr.Body.String(), expected) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
 }
 
 func TestSendMessageBatch_POST_IdNotDistinct(t *testing.T) {


### PR DESCRIPTION
I forgot to check the existence of the queue during the SendMessageBatch request. 😒 With this PR I'm adding that check. 

I also realized that one other check against the EmptyBatchRequest error was missing. I've added that one, too. 

#139 introduced a bug which prevented us from deleting messages due to an incorrect struct referencing. This PR also fixes that issue. 