### PR TITLE
Add ChangeMessageVisibility endpoint and implement VisibilityTimeout logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/p4tin/goaws.svg?branch=master)](https://travis-ci.org/p4tin/goaws)
 
 You are always welcome to [tweet me](https://twitter.com/gocodecloud) or [buy me a coffee](https://www.paypal.me/p4tin)
- 
+
 Written in Go this is a clone of the AWS SQS/SNS systems.  This system is designed to emulate SQS and SNS in a local environment so developers can test their interfaces without having to connect to the AWS Cloud and possibly incurring the expense, or even worse actually write to production topics/queues by mistake.  If you see any problems or would like to see a new feature, please open an issue here in github.  As well, I will logon to Gitter so we can discuss your deployment issues or the weather.
 
 
@@ -17,10 +17,20 @@ Here is a list of the APIs:
  - [x] GetQueueAttributes (Always returns all attributes - depth and arn are set correctly others are mocked)
  - [x] GetQueueUrl
  - [x] SendMessage
+ - [x] SendMessageBatch
  - [x] ReceiveMessage
  - [x] DeleteMessage
+ - [x] DeleteMessageBatch
  - [x] PurgeQueue
  - [x] Delete Queue
+ - [x] ChangeMessageVisibility
+ - [ ] ChangeMessageVisibilityBatch
+ - [ ] ListDeadLetterSourceQueues
+ - [ ] ListQueueTags
+ - [ ] RemovePermission
+ - [ ] SetQueueAttributes
+ - [ ] TagQueue
+ - [ ] UntagQueue
 
 ## Current SNS APIs implemented:
 
@@ -33,10 +43,10 @@ Here is a list of the APIs:
  - [x] Subscribe
  - [x] Unsubscribe
  - [X] ListSubscriptionsByTopic
- 
+
 ## Yaml Configuration Implemented
 
- - [x] Read config file 
+ - [x] Read config file
  - [x] -config flag to read a specific configuration file (e.g.: -config=myconfig.yaml)
  - [x] a command line argument to determine the environment to use in the config file (e.e.: Dev)
  - [x] IN the config file to can create Queues, Topic and Subscription see the example config file in the conf directory
@@ -54,16 +64,16 @@ Here is a list of the APIs:
     Build
         cd to GoAws directory
         go build -o goaws app/cmd/goaws.go  (The goaws executable should be in the currect directory, move it somewhere in your $PATH)
-        
+
     Run
         ./goaws  (by default goaws listens on port 4100 but you can change it in the goaws.yaml file to another port of your choice)
-        
+
 
 ## Run (Docker Version)
 
     Get it
         docker pull pafortin/goaws
-        
+
     run
         docker run -d --name goaws -p 4100:4100 pafortin/goaws
 
@@ -77,13 +87,13 @@ You can test that your installation is working correctly in one of two ways:
 
  2. by using the AWS cli tools ([download link](http://docs.aws.amazon.com/cli/latest/userguide/installing.html)) here are some samples, you can refer to the [aws cli tools docs](http://docs.aws.amazon.com/cli/latest/reference/) for further information.
 
-* aws --endpoint-url http://localhost:4100 sqs create-queue --queue-name test1  
+* aws --endpoint-url http://localhost:4100 sqs create-queue --queue-name test1
 ```
     {
         "QueueUrl": "http://localhost:4100/test1"
     }
 ```
-* aws --endpoint-url http://localhost:4100 sqs list-queues  
+* aws --endpoint-url http://localhost:4100 sqs list-queues
 ```
     {
         "QueueUrls": [
@@ -94,30 +104,30 @@ You can test that your installation is working correctly in one of two ways:
 * aws --endpoint-url http://localhost:4100 sqs send-message --queue-url http://localhost:4100/test1 --message-body "this is a test of the GoAws Queue messaging"
 ```
     {
-        "MD5OfMessageBody": "9d3f5eaac3b1b4dd509f39e71e25f954", 
-        "MD5OfMessageAttributes": "b095c6d16871105acb75d59332513337", 
+        "MD5OfMessageBody": "9d3f5eaac3b1b4dd509f39e71e25f954",
+        "MD5OfMessageAttributes": "b095c6d16871105acb75d59332513337",
         "MessageId": "66a1b4f5-cecf-473e-92b6-810156d41bbe"
     }
 ```
-* aws --endpoint-url http://localhost:4100 sqs receive-message --queue-url http://localhost:4100/test1  
+* aws --endpoint-url http://localhost:4100 sqs receive-message --queue-url http://localhost:4100/test1
 ```
     {
         "Messages": [
             {
-                "Body": "this is a test of the GoAws Queue messaging", 
-                "MD5OfMessageAttributes": "b095c6d16871105acb75d59332513337", 
-                "ReceiptHandle": "66a1b4f5-cecf-473e-92b6-810156d41bbe#f1fc455c-698e-442e-9747-f415bee5b461", 
-                "MD5OfBody": "9d3f5eaac3b1b4dd509f39e71e25f954", 
+                "Body": "this is a test of the GoAws Queue messaging",
+                "MD5OfMessageAttributes": "b095c6d16871105acb75d59332513337",
+                "ReceiptHandle": "66a1b4f5-cecf-473e-92b6-810156d41bbe#f1fc455c-698e-442e-9747-f415bee5b461",
+                "MD5OfBody": "9d3f5eaac3b1b4dd509f39e71e25f954",
                 "MessageId": "66a1b4f5-cecf-473e-92b6-810156d41bbe"
             }
         ]
     }
 ```
-* aws --endpoint-url http://localhost:4100 sqs delete-message --queue-url http://localhost:4100/test1 --receipt-handle 66a1b4f5-cecf-473e-92b6-810156d41bbe#f1fc455c-698e-442e-9747-f415bee5b461  
+* aws --endpoint-url http://localhost:4100 sqs delete-message --queue-url http://localhost:4100/test1 --receipt-handle 66a1b4f5-cecf-473e-92b6-810156d41bbe#f1fc455c-698e-442e-9747-f415bee5b461
 ```
     No output
 ```
-* aws --endpoint-url http://localhost:4100 sqs receive-message --queue-url http://localhost:4100/test1  
+* aws --endpoint-url http://localhost:4100 sqs receive-message --queue-url http://localhost:4100/test1
 ```
     No output (No messages in Q)
 ```
@@ -136,7 +146,7 @@ You can test that your installation is working correctly in one of two ways:
         "Topics": [
             {
                 "TopicArn": "arn:aws:sns:local:000000000000:topic1"
-            }, 
+            },
             {
                 "TopicArn": "arn:aws:sns:local:000000000000:topic2"
             }

--- a/app/cmd/goaws.go
+++ b/app/cmd/goaws.go
@@ -4,10 +4,12 @@ import (
 	"flag"
 	"net/http"
 	"os"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/p4tin/goaws/app/conf"
+	"github.com/p4tin/goaws/app/gosqs"
 	"github.com/p4tin/goaws/app/router"
 )
 
@@ -34,6 +36,9 @@ func main() {
 	portNumbers := conf.LoadYamlConfig(filename, env)
 
 	r := router.New()
+
+	quit := make(chan struct{}, 0)
+	go gosqs.PeriodicTasks(1*time.Second, quit)
 
 	if len(portNumbers) == 1 {
 		log.Warnf("GoAws listening on: 0.0.0.0:%s", portNumbers[0])

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -165,6 +165,10 @@ func SendMessageBatch(w http.ResponseWriter, req *http.Request) {
 	for k, v := range req.Form {
 		keySegments := strings.Split(k, ".")
 		if keySegments[0] == "SendMessageBatchRequestEntry" {
+			if len(keySegments) < 3 {
+				createErrorResponse(w, req, "EmptyBatchRequest")
+				return
+			}
 			keyIndex, err := strconv.Atoi(keySegments[1])
 
 			if err != nil {

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -305,10 +305,10 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 				app.SyncQueues.Lock() // Lock the Queues
 				uuid, _ := common.NewUUID()
 
-				msg := app.SyncQueues.Queues[queueName].Messages[i]
+				msg := &app.SyncQueues.Queues[queueName].Messages[i]
 				msg.ReceiptHandle = msg.Uuid + "#" + uuid
 				msg.ReceiptTime = time.Now()
-				message = append(message, getMessageResult(&msg))
+				message = append(message, getMessageResult(msg))
 
 				app.SyncQueues.Unlock() // Unlock the Queues
 				numMsg++

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -155,6 +155,11 @@ func SendMessageBatch(w http.ResponseWriter, req *http.Request) {
 		queueName = uriSegments[len(uriSegments)-1]
 	}
 
+	if _, ok := app.SyncQueues.Queues[queueName]; !ok {
+		createErrorResponse(w, req, "QueueNotFound")
+		return
+	}
+
 	sendEntries := []SendEntry{}
 
 	for k, v := range req.Form {

--- a/app/gosqs/gosqs_test.go
+++ b/app/gosqs/gosqs_test.go
@@ -229,6 +229,24 @@ func TestSendMessageBatch_POST_NoEntry(t *testing.T) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)
 	}
+
+	req, _ = http.NewRequest("POST", "/", nil)
+	form.Add("SendMessageBatchRequestEntry", "")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+
+	if !strings.Contains(rr.Body.String(), expected) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
 }
 
 func TestSendMessageBatch_POST_IdNotDistinct(t *testing.T) {

--- a/app/gosqs/gosqs_test.go
+++ b/app/gosqs/gosqs_test.go
@@ -540,7 +540,7 @@ func TestRequeueing_VisibilityTimeoutExpires(t *testing.T) {
 	if ok := strings.Contains(rr.Body.String(), "<Message>"); ok {
 		t.Fatal("handler should not return a message")
 	}
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	// message needs to be requeued
 	req, err = http.NewRequest("POST", "/", nil)

--- a/app/gosqs/gosqs_test.go
+++ b/app/gosqs/gosqs_test.go
@@ -1,11 +1,14 @@
 package gosqs
 
 import (
+	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/p4tin/goaws/app"
 )
@@ -97,9 +100,12 @@ func TestCreateQueuehandler_POST_CreateQueue(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	queueName := "UnitTestQueue1"
 	form := url.Values{}
 	form.Add("Action", "CreateQueue")
 	form.Add("QueueName", "UnitTestQueue1")
+	form.Add("Attribute.1.Name", "VisibilityTimeout")
+	form.Add("Attribute.1.Value", "60")
 	req.PostForm = form
 
 	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
@@ -117,10 +123,20 @@ func TestCreateQueuehandler_POST_CreateQueue(t *testing.T) {
 	}
 
 	// Check the response body is what we expect.
-	expected := "UnitTestQueue1"
+	expected := queueName
 	if !strings.Contains(rr.Body.String(), expected) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)
+	}
+	expectedQueue := &app.Queue{
+		Name:        queueName,
+		URL:         "http://:/queue/" + queueName,
+		Arn:         "arn:aws:sqs::000000000000:" + queueName,
+		TimeoutSecs: 60,
+	}
+	actualQueue := app.SyncQueues.Queues[queueName]
+	if !reflect.DeepEqual(expectedQueue, actualQueue) {
+		t.Fatalf("expected %+v, got %+v", expectedQueue, actualQueue)
 	}
 }
 
@@ -403,7 +419,7 @@ func TestChangeMessageVisibility_POST_SUCCESS(t *testing.T) {
 	}}
 
 	form := url.Values{}
-	form.Add("Action", "SendMessageBatch")
+	form.Add("Action", "ChangeMessageVisibility")
 	form.Add("QueueUrl", "http://localhost:4100/queue/testing")
 	form.Add("VisibilityTimeout", "0")
 	form.Add("ReceiptHandle", "123")
@@ -430,4 +446,271 @@ func TestChangeMessageVisibility_POST_SUCCESS(t *testing.T) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)
 	}
+}
+
+func TestRequeueing_VisibilityTimeoutExpires(t *testing.T) {
+	done := make(chan struct{}, 0)
+	go PeriodicTasks(1*time.Second, done)
+
+	// create a queue
+	req, err := http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Add("Action", "CreateQueue")
+	form.Add("QueueName", "requeue")
+	form.Add("Attribute.1.Name", "VisibilityTimeout")
+	form.Add("Attribute.1.Value", "1")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(CreateQueue).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+
+	// send a message
+	req, err = http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form = url.Values{}
+	form.Add("Action", "SendMessage")
+	form.Add("QueueUrl", "http://localhost:4100/queue/requeue")
+	form.Add("MessageBody", "1")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+	http.HandlerFunc(SendMessage).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+
+	// receive message
+	req, err = http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form = url.Values{}
+	form.Add("Action", "ReceiveMessage")
+	form.Add("QueueUrl", "http://localhost:4100/queue/requeue")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+	http.HandlerFunc(ReceiveMessage).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+	if ok := strings.Contains(rr.Body.String(), "<Message>"); !ok {
+		t.Fatal("handler should return a message")
+	}
+
+	// try to receive another message.
+	req, err = http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form = url.Values{}
+	form.Add("Action", "ReceiveMessage")
+	form.Add("QueueUrl", "http://localhost:4100/queue/requeue")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+	http.HandlerFunc(ReceiveMessage).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+	if ok := strings.Contains(rr.Body.String(), "<Message>"); ok {
+		t.Fatal("handler should not return a message")
+	}
+	time.Sleep(1 * time.Second)
+
+	// message needs to be requeued
+	req, err = http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form = url.Values{}
+	form.Add("Action", "ReceiveMessage")
+	form.Add("QueueUrl", "http://localhost:4100/queue/requeue")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+	http.HandlerFunc(ReceiveMessage).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+	if ok := strings.Contains(rr.Body.String(), "<Message>"); !ok {
+		t.Fatal("handler should return a message")
+	}
+	done <- struct{}{}
+}
+
+func TestRequeueing_ResetVisibilityTimeout(t *testing.T) {
+	done := make(chan struct{}, 0)
+	go PeriodicTasks(1*time.Second, done)
+
+	// create a queue
+	req, err := http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Add("Action", "CreateQueue")
+	form.Add("QueueName", "requeue-reset")
+	form.Add("Attribute.1.Name", "VisibilityTimeout")
+	form.Add("Attribute.1.Value", "10")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(CreateQueue).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+
+	// send a message
+	req, err = http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form = url.Values{}
+	form.Add("Action", "SendMessage")
+	form.Add("QueueUrl", "http://localhost:4100/queue/requeue-reset")
+	form.Add("MessageBody", "1")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+	http.HandlerFunc(SendMessage).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+
+	// receive message
+	req, err = http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form = url.Values{}
+	form.Add("Action", "ReceiveMessage")
+	form.Add("QueueUrl", "http://localhost:4100/queue/requeue-reset")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+	http.HandlerFunc(ReceiveMessage).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+	if ok := strings.Contains(rr.Body.String(), "<Message>"); !ok {
+		t.Fatal("handler should return a message")
+	}
+
+	resp := app.ReceiveMessageResponse{}
+	err = xml.Unmarshal(rr.Body.Bytes(), &resp)
+	if err != nil {
+		t.Fatalf("unexpected unmarshal error: %s", err)
+	}
+	receiptHandle := resp.Result.Message[0].ReceiptHandle
+
+	// try to receive another message.
+	req, err = http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form = url.Values{}
+	form.Add("Action", "ReceiveMessage")
+	form.Add("QueueUrl", "http://localhost:4100/queue/requeue-reset")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+	http.HandlerFunc(ReceiveMessage).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+	if ok := strings.Contains(rr.Body.String(), "<Message>"); ok {
+		t.Fatal("handler should not return a message")
+	}
+
+	// reset message visibility timeout to requeue it
+	req, err = http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form = url.Values{}
+	form.Add("Action", "ChangeMessageVisibility")
+	form.Add("QueueUrl", "http://localhost:4100/queue/requeue-reset")
+	form.Add("VisibilityTimeout", "0")
+	form.Add("ReceiptHandle", receiptHandle)
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+	http.HandlerFunc(ChangeMessageVisibility).ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+
+	// message needs to be requeued
+	req, err = http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form = url.Values{}
+	form.Add("Action", "ReceiveMessage")
+	form.Add("QueueUrl", "http://localhost:4100/queue/requeue-reset")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	rr = httptest.NewRecorder()
+	http.HandlerFunc(ReceiveMessage).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+	if ok := strings.Contains(rr.Body.String(), "<Message>"); !ok {
+		t.Fatal("handler should return a message")
+	}
+	done <- struct{}{}
 }

--- a/app/gosqs/gosqs_test.go
+++ b/app/gosqs/gosqs_test.go
@@ -389,3 +389,45 @@ func TestSendMessageBatch_POST_Success(t *testing.T) {
 			rr.Body.String(), expected)
 	}
 }
+
+func TestChangeMessageVisibility_POST_SUCCESS(t *testing.T) {
+	req, err := http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app.SyncQueues.Queues["testing"] = &app.Queue{Name: "testing"}
+	app.SyncQueues.Queues["testing"].Messages = []app.Message{{
+		MessageBody:   []byte("test1"),
+		ReceiptHandle: "123",
+	}}
+
+	form := url.Values{}
+	form.Add("Action", "SendMessageBatch")
+	form.Add("QueueUrl", "http://localhost:4100/queue/testing")
+	form.Add("VisibilityTimeout", "0")
+	form.Add("ReceiptHandle", "123")
+	form.Add("Version", "2012-11-05")
+	req.PostForm = form
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(ChangeMessageVisibility)
+
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder.
+	handler.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got \n%v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the response body is what we expect.
+	expected := `<ChangeMessageVisibilityResult xmlns="http://queue.amazonaws.com/doc/2012-11-05/">`
+	if !strings.Contains(rr.Body.String(), expected) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}

--- a/app/gosqs/queue_attributes.go
+++ b/app/gosqs/queue_attributes.go
@@ -1,0 +1,38 @@
+package gosqs
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/p4tin/goaws/app"
+)
+
+// applyQueueAttributes applies the requested queue attributes to the given
+// queue.
+// TODO Currently it only supports the VisibilityTimeout attribute.
+func applyQueueAttributes(q *app.Queue, u url.Values) {
+	attr := extractQueueAttributes(u)
+	visibilityTimeout, _ := strconv.Atoi(attr["VisibilityTimeout"])
+	if visibilityTimeout != 0 {
+		q.TimeoutSecs = visibilityTimeout
+	}
+}
+
+func extractQueueAttributes(u url.Values) map[string]string {
+	attr := map[string]string{}
+	for i := 1; true; i++ {
+		nameKey := fmt.Sprintf("Attribute.%d.Name", i)
+		attrName := u.Get(nameKey)
+		if attrName == "" {
+			break
+		}
+
+		valueKey := fmt.Sprintf("Attribute.%d.Value", i)
+		attrValue := u.Get(valueKey)
+		if attrValue != "" {
+			attr[attrName] = attrValue
+		}
+	}
+	return attr
+}

--- a/app/gosqs/queue_attributes.go
+++ b/app/gosqs/queue_attributes.go
@@ -1,22 +1,66 @@
 package gosqs
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/p4tin/goaws/app"
 )
 
-// applyQueueAttributes applies the requested queue attributes to the given
+var (
+	ErrInvalidParameterValue = &app.SqsErrorType{
+		HttpError: http.StatusBadRequest,
+		Type:      "InvalidParameterValue",
+		Code:      "AWS.SimpleQueueService.InvalidParameterValue",
+		Message:   "An invalid or out-of-range value was supplied for the input parameter.",
+	}
+	ErrInvalidAttributeValue = &app.SqsErrorType{
+		HttpError: http.StatusBadRequest,
+		Type:      "InvalidAttributeValue",
+		Code:      "AWS.SimpleQueueService.InvalidAttributeValue",
+		Message:   "Invalid Value for the parameter RedrivePolicy.",
+	}
+)
+
+// validateQueueAttributes applies the requested queue attributes to the given
 // queue.
-// TODO Currently it only supports the VisibilityTimeout attribute.
-func applyQueueAttributes(q *app.Queue, u url.Values) {
+// TODO Currently it only supports VisibilityTimeout and RedrivePolicy attributes.
+func validateQueueAttributes(q *app.Queue, u url.Values) error {
 	attr := extractQueueAttributes(u)
 	visibilityTimeout, _ := strconv.Atoi(attr["VisibilityTimeout"])
 	if visibilityTimeout != 0 {
 		q.TimeoutSecs = visibilityTimeout
 	}
+	redrivePolicy := attr["RedrivePolicy"]
+	if redrivePolicy != "" {
+		str := struct {
+			MaxReceiveCount     int    `json:"maxReceiveCount"`
+			DeadLetterTargetArn string `json:"deadLetterTargetArn"`
+		}{}
+		err := json.Unmarshal([]byte(redrivePolicy), &str)
+		if err != nil {
+			return ErrInvalidAttributeValue
+		}
+
+		if (str.DeadLetterTargetArn != "" && str.MaxReceiveCount == 0) ||
+			(str.DeadLetterTargetArn == "" && str.MaxReceiveCount != 0) {
+			return ErrInvalidParameterValue
+		}
+		dlt := strings.Split(str.DeadLetterTargetArn, ":")
+		deadLetterQueueName := dlt[len(dlt)-1]
+		deadLetterQueue, ok := app.SyncQueues.Queues[deadLetterQueueName]
+		if !ok {
+			return ErrInvalidParameterValue
+		}
+		q.DeadLetterQueue = deadLetterQueue
+		q.MaxReceiveCount = str.MaxReceiveCount
+	}
+
+	return nil
 }
 
 func extractQueueAttributes(u url.Values) map[string]string {

--- a/app/gosqs/queue_attributes_test.go
+++ b/app/gosqs/queue_attributes_test.go
@@ -1,0 +1,41 @@
+package gosqs
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/p4tin/goaws/app"
+)
+
+func TestApplyQueueAttributes(t *testing.T) {
+	q := &app.Queue{TimeoutSecs: 30}
+	u := url.Values{}
+	u.Add("Attribute.1.Name", "DelaySeconds")
+	u.Add("Attribute.1.Value", "20")
+	u.Add("Attribute.2.Name", "VisibilityTimeout")
+	u.Add("Attribute.2.Value", "60")
+	u.Add("Attribute.3.Name", "Policy")
+	applyQueueAttributes(q, u)
+	expected := &app.Queue{TimeoutSecs: 60}
+	if ok := reflect.DeepEqual(q, expected); !ok {
+		t.Fatalf("expected %+v, got %+v", expected, q)
+	}
+}
+
+func TestExtractQueueAttributes(t *testing.T) {
+	u := url.Values{}
+	u.Add("Attribute.1.Name", "DelaySeconds")
+	u.Add("Attribute.1.Value", "20")
+	u.Add("Attribute.2.Name", "VisibilityTimeout")
+	u.Add("Attribute.2.Value", "30")
+	u.Add("Attribute.3.Name", "Policy")
+	attr := extractQueueAttributes(u)
+	expected := map[string]string{
+		"DelaySeconds":      "20",
+		"VisibilityTimeout": "30",
+	}
+	if ok := reflect.DeepEqual(attr, expected); !ok {
+		t.Fatalf("expected %+v, got %+v", expected, attr)
+	}
+}

--- a/app/gosqs/queue_attributes_test.go
+++ b/app/gosqs/queue_attributes_test.go
@@ -9,18 +9,52 @@ import (
 )
 
 func TestApplyQueueAttributes(t *testing.T) {
-	q := &app.Queue{TimeoutSecs: 30}
-	u := url.Values{}
-	u.Add("Attribute.1.Name", "DelaySeconds")
-	u.Add("Attribute.1.Value", "20")
-	u.Add("Attribute.2.Name", "VisibilityTimeout")
-	u.Add("Attribute.2.Value", "60")
-	u.Add("Attribute.3.Name", "Policy")
-	applyQueueAttributes(q, u)
-	expected := &app.Queue{TimeoutSecs: 60}
-	if ok := reflect.DeepEqual(q, expected); !ok {
-		t.Fatalf("expected %+v, got %+v", expected, q)
-	}
+	t.Run("success", func(t *testing.T) {
+		deadLetterQueue := &app.Queue{Name: "failed-messages"}
+		app.SyncQueues.Lock()
+		app.SyncQueues.Queues["failed-messages"] = deadLetterQueue
+		app.SyncQueues.Unlock()
+		q := &app.Queue{TimeoutSecs: 30}
+		u := url.Values{}
+		u.Add("Attribute.1.Name", "DelaySeconds")
+		u.Add("Attribute.1.Value", "20")
+		u.Add("Attribute.2.Name", "VisibilityTimeout")
+		u.Add("Attribute.2.Value", "60")
+		u.Add("Attribute.3.Name", "Policy")
+		u.Add("Attribute.4.Name", "RedrivePolicy")
+		u.Add("Attribute.4.Value", `{"maxReceiveCount": 4, "deadLetterTargetArn":"arn:aws:sqs::000000000000:failed-messages"}`)
+		if err := validateQueueAttributes(q, u); err != nil {
+			t.Fatalf("expected nil, got %s", err)
+		}
+		expected := &app.Queue{
+			TimeoutSecs:     60,
+			MaxReceiveCount: 4,
+			DeadLetterQueue: deadLetterQueue,
+		}
+		if ok := reflect.DeepEqual(q, expected); !ok {
+			t.Fatalf("expected %+v, got %+v", expected, q)
+		}
+	})
+	t.Run("missing_deadletter_arn", func(t *testing.T) {
+		q := &app.Queue{TimeoutSecs: 30}
+		u := url.Values{}
+		u.Add("Attribute.1.Name", "RedrivePolicy")
+		u.Add("Attribute.1.Value", `{"maxReceiveCount": 4}`)
+		err := validateQueueAttributes(q, u)
+		if err != ErrInvalidParameterValue {
+			t.Fatalf("expected %s, got %s", ErrInvalidParameterValue, err)
+		}
+	})
+	t.Run("invalid_redrive_policy", func(t *testing.T) {
+		q := &app.Queue{TimeoutSecs: 30}
+		u := url.Values{}
+		u.Add("Attribute.1.Name", "RedrivePolicy")
+		u.Add("Attribute.1.Value", `{invalidinput}`)
+		err := validateQueueAttributes(q, u)
+		if err != ErrInvalidAttributeValue {
+			t.Fatalf("expected %s, got %s", ErrInvalidAttributeValue, err)
+		}
+	})
 }
 
 func TestExtractQueueAttributes(t *testing.T) {

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -23,18 +23,19 @@ func New() http.Handler {
 
 var routingTable = map[string]http.HandlerFunc{
 	// SQS
-	"ListQueues":         sqs.ListQueues,
-	"CreateQueue":        sqs.CreateQueue,
-	"GetQueueAttributes": sqs.GetQueueAttributes,
-	"SetQueueAttributes": sqs.SetQueueAttributes,
-	"SendMessage":        sqs.SendMessage,
-	"SendMessageBatch":   sqs.SendMessageBatch,
-	"ReceiveMessage":     sqs.ReceiveMessage,
-	"DeleteMessage":      sqs.DeleteMessage,
-	"DeleteMessageBatch": sqs.DeleteMessageBatch,
-	"GetQueueUrl":        sqs.GetQueueUrl,
-	"PurgeQueue":         sqs.PurgeQueue,
-	"DeleteQueue":        sqs.DeleteQueue,
+	"ListQueues":              sqs.ListQueues,
+	"CreateQueue":             sqs.CreateQueue,
+	"GetQueueAttributes":      sqs.GetQueueAttributes,
+	"SetQueueAttributes":      sqs.SetQueueAttributes,
+	"SendMessage":             sqs.SendMessage,
+	"SendMessageBatch":        sqs.SendMessageBatch,
+	"ReceiveMessage":          sqs.ReceiveMessage,
+	"DeleteMessage":           sqs.DeleteMessage,
+	"DeleteMessageBatch":      sqs.DeleteMessageBatch,
+	"GetQueueUrl":             sqs.GetQueueUrl,
+	"PurgeQueue":              sqs.PurgeQueue,
+	"DeleteQueue":             sqs.DeleteQueue,
+	"ChangeMessageVisibility": sqs.ChangeMessageVisibility,
 
 	// SNS
 	"ListTopics":                sns.ListTopics,

--- a/app/sqs.go
+++ b/app/sqs.go
@@ -21,6 +21,8 @@ type Message struct {
 	MD5OfMessageBody       string
 	ReceiptHandle          string
 	ReceiptTime            time.Time
+	VisibilityTimeout      time.Time
+	Retry                  int
 	MessageAttributes      map[string]MessageAttributeValue
 }
 

--- a/app/sqs.go
+++ b/app/sqs.go
@@ -12,6 +12,10 @@ type SqsErrorType struct {
 	Message   string
 }
 
+func (s *SqsErrorType) Error() string {
+	return s.Type
+}
+
 var SqsErrors map[string]SqsErrorType
 
 type Message struct {
@@ -34,11 +38,13 @@ type MessageAttributeValue struct {
 }
 
 type Queue struct {
-	Name        string
-	URL         string
-	Arn         string
-	TimeoutSecs int
-	Messages    []Message
+	Name            string
+	URL             string
+	Arn             string
+	TimeoutSecs     int
+	Messages        []Message
+	DeadLetterQueue *Queue
+	MaxReceiveCount int
 }
 
 var SyncQueues = struct {

--- a/app/sqs_messages.go
+++ b/app/sqs_messages.go
@@ -68,6 +68,11 @@ type ReceiveMessageResponse struct {
 	Metadata ResponseMetadata     `xml:"ResponseMetadata"`
 }
 
+type ChangeMessageVisibilityResult struct {
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
 /*** Delete Message Response */
 type DeleteMessageResponse struct {
 	Xmlns    string           `xml:"xmlns,attr,omitempty"`


### PR DESCRIPTION
This PR introduces ChangeMessageVisibility endpoint and requeueing logic behind VisibilityTimeout. Mutex locking is becoming too strict, which needs to be improved later on.

I've also added DeadLetter Queue support. 

The PR also includes the changes from #143 and closes #85 