### PR TITLE
Implement SQS ReceiveMessageWaitTimeSeconds attribute and Subscribe to SNS with SQS arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All SNS/SQS APIs have been implemented except:
 Here is a list of the APIs:
  - [x] ListQueues
  - [x] CreateQueue
- - [x] GetQueueAttributes (Always returns all attributes - depth and arn are set correctly others are mocked)
+ - [x] GetQueueAttributes (Always returns all attributes - unsupporterd arttributes are mocked)
  - [x] GetQueueUrl
  - [x] SendMessage
  - [x] SendMessageBatch
@@ -28,9 +28,15 @@ Here is a list of the APIs:
  - [ ] ListDeadLetterSourceQueues
  - [ ] ListQueueTags
  - [ ] RemovePermission
- - [ ] SetQueueAttributes
+ - [x] SetQueueAttributes (Only supported attributes are set - see Supported Queue Attributes)
  - [ ] TagQueue
  - [ ] UntagQueue
+
+## Supported Queue Attributes
+
+ - [x] VisibilityTimeout
+ - [x] ReceiveMessageWaitTimeSeconds
+ - [x] RedrivePolicy
 
 ## Current SNS APIs implemented:
 
@@ -49,7 +55,7 @@ Here is a list of the APIs:
  - [x] Read config file
  - [x] -config flag to read a specific configuration file (e.g.: -config=myconfig.yaml)
  - [x] a command line argument to determine the environment to use in the config file (e.e.: Dev)
- - [x] IN the config file to can create Queues, Topic and Subscription see the example config file in the conf directory
+ - [x] IN the config file you can create Queues, Topic and Subscription see the example config file in the conf directory
 
 ## Debug logging can be turned on via a command line flag (e.g.: -debug)
 

--- a/app/common.go
+++ b/app/common.go
@@ -12,7 +12,8 @@ type EnvTopic struct {
 }
 
 type EnvQueue struct {
-	Name string
+	Name                          string
+	ReceiveMessageWaitTimeSeconds int
 }
 
 type Environment struct {

--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -62,7 +62,7 @@ func LoadYamlConfig(filename string, env string) []string {
 	for _, queue := range envs[env].Queues {
 		queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port + "/queue/" + queue.Name
 		queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":000000000000:" + queue.Name
-		app.SyncQueues.Queues[queue.Name] = &app.Queue{Name: queue.Name, TimeoutSecs: 30, Arn: queueArn, URL: queueUrl}
+		app.SyncQueues.Queues[queue.Name] = &app.Queue{Name: queue.Name, TimeoutSecs: 30, Arn: queueArn, URL: queueUrl, ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds}
 	}
 
 	for _, topic := range envs[env].Topics {
@@ -78,8 +78,8 @@ func LoadYamlConfig(filename string, env string) []string {
 				queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":000000000000:" + subs.QueueName
 				app.SyncQueues.Queues[subs.QueueName] = &app.Queue{Name: subs.QueueName, TimeoutSecs: 30, Arn: queueArn, URL: queueUrl}
 			}
-			qUrl := app.SyncQueues.Queues[subs.QueueName].URL
-			newSub := &app.Subscription{EndPoint: qUrl, Protocol: "sqs", TopicArn: topicArn, Raw: subs.Raw}
+			qArn := app.SyncQueues.Queues[subs.QueueName].Arn
+			newSub := &app.Subscription{EndPoint: qArn, Protocol: "sqs", TopicArn: topicArn, Raw: subs.Raw}
 			subArn, _ := common.NewUUID()
 			subArn = topicArn + ":" + subArn
 			newSub.SubscriptionArn = subArn

--- a/app/conf/config_test.go
+++ b/app/conf/config_test.go
@@ -61,4 +61,9 @@ func TestConfig_CreateQueuesTopicsAndSubscriptions(t *testing.T) {
 	if numSubscriptions != 2 {
 		t.Errorf("Expected two Subscriptions to be in the environment but got %s\n", numTopics)
 	}
+
+	receiveWaitTime := app.SyncQueues.Queues["local-queue2"].ReceiveWaitTimeSecs
+	if receiveWaitTime != 20 {
+		t.Errorf("Expected local-queue2 Queue to be configured with ReceiveMessageWaitTimeSeconds: 20 but got %s\n", receiveWaitTime)
+	}
 }

--- a/app/conf/goaws.yaml
+++ b/app/conf/goaws.yaml
@@ -10,8 +10,9 @@ Local:                              # Environment name that can be passed on the
   LogMessages: true                 # Log messages (true/false)
   LogFile: ./goaws_messages.log  # Log filename (for message logging
   Queues:                           # List of queues to create at startup
-    - Name: local-queue1            # Queue name
-    - Name: local-queue2            # Queue name
+    - Name: local-queue1                # Queue name
+    - Name: local-queue2                # Queue name
+      ReceiveMessageWaitTimeSeconds: 20 # Queue receive message max wait time
   Topics:                           # List of topic to create at startup
     - Name: local-topic1            # Topic name - with some Subscriptions
       Subscriptions:                # List of Subscriptions to create for this topic (queues will be created as required)

--- a/app/conf/mock-data/mock-config.yaml
+++ b/app/conf/mock-data/mock-config.yaml
@@ -3,11 +3,12 @@ Local:                              # Environment name that can be passed on the
   Host: localhost                   # hostname of the goaws system  (for docker-compose this is the tag name of the container)
   Port: 4100                        # port to listen on.
   LogMessages: true                 # Log messages (true/false)
-  LogFile: ./goaws_messages.log  # Log filename (for message logging
+  LogFile: ./goaws_messages.log     # Log filename (for message logging
   Queues:                           # List of queues to create at startup
-    - Name: local-queue1            # Queue name
-    - Name: local-queue2            # Queue name
-    - Name: local-queue3            # Queue name
+    - Name: local-queue1                # Queue name
+    - Name: local-queue2                # Queue name
+      ReceiveMessageWaitTimeSeconds: 20 # Queue receive message max wait time
+    - Name: local-queue3                # Queue name
   Topics:                           # List of topic to create at startup
     - Name: local-topic1            # Topic name - with some Subscriptions
       Subscriptions:                # List of Subscriptions to create for this topic (queues will be created as required)

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -115,7 +115,7 @@ func CreateQueue(w http.ResponseWriter, req *http.Request) {
 			Arn:         queueArn,
 			TimeoutSecs: 30,
 		}
-		if err := validateQueueAttributes(queue, req.Form); err != nil {
+		if err := validateAndSetQueueAttributes(queue, req.Form); err != nil {
 			createErrorResponse(w, req, err.Error())
 			return
 		}
@@ -333,11 +333,17 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 	//	respMsg := ResultMessage{}
 	respStruct := app.ReceiveMessageResponse{}
 
+	if waitTimeSeconds == 0 {
+		app.SyncQueues.RLock()
+		waitTimeSeconds = app.SyncQueues.Queues[queueName].ReceiveWaitTimeSecs
+		app.SyncQueues.RUnlock()
+	}
+
 	loops := waitTimeSeconds * 10
 	for loops > 0 {
-		app.SyncQueues.Lock()
+		app.SyncQueues.RLock()
 		found := len(app.SyncQueues.Queues[queueName].Messages)-numberOfHiddenMessagesInQueue(*app.SyncQueues.Queues[queueName]) != 0
-		app.SyncQueues.Unlock()
+		app.SyncQueues.RUnlock()
 		if !found {
 			time.Sleep(100 * time.Millisecond)
 			loops--
@@ -396,13 +402,11 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 
 func numberOfHiddenMessagesInQueue(queue app.Queue) int {
 	num := 0
-	app.SyncQueues.Lock()
 	for i := range queue.Messages {
 		if queue.Messages[i].ReceiptHandle != "" {
 			num++
 		}
 	}
-	app.SyncQueues.Unlock()
 	return num
 }
 
@@ -714,6 +718,7 @@ func GetQueueAttributes(w http.ResponseWriter, req *http.Request) {
 	}
 
 	log.Println("Get Queue Attributes:", queueName)
+	app.SyncQueues.RLock()
 	if queue, ok := app.SyncQueues.Queues[queueName]; ok {
 		// Create, encode/xml and send response
 		attribs := make([]app.Attribute, 0, 0)
@@ -721,7 +726,7 @@ func GetQueueAttributes(w http.ResponseWriter, req *http.Request) {
 		attribs = append(attribs, attr)
 		attr = app.Attribute{Name: "DelaySeconds", Value: "0"}
 		attribs = append(attribs, attr)
-		attr = app.Attribute{Name: "ReceiveMessageWaitTimeSeconds", Value: "0"}
+		attr = app.Attribute{Name: "ReceiveMessageWaitTimeSeconds", Value: strconv.Itoa(queue.ReceiveWaitTimeSecs)}
 		attribs = append(attribs, attr)
 		attr = app.Attribute{Name: "ApproximateNumberOfMessages", Value: strconv.Itoa(len(queue.Messages))}
 		attribs = append(attribs, attr)
@@ -732,6 +737,13 @@ func GetQueueAttributes(w http.ResponseWriter, req *http.Request) {
 		attr = app.Attribute{Name: "LastModifiedTimestamp", Value: "0000000000"}
 		attribs = append(attribs, attr)
 		attr = app.Attribute{Name: "QueueArn", Value: queue.Arn}
+		attribs = append(attribs, attr)
+
+		deadLetterTargetArn := ""
+		if queue.DeadLetterQueue != nil {
+			deadLetterTargetArn = queue.DeadLetterQueue.Name
+		}
+		attr = app.Attribute{Name: "RedrivePolicy", Value: fmt.Sprintf(`{"maxReceiveCount": "%d", "deadLetterTargetArn":"%s"}`, queue.MaxReceiveCount, deadLetterTargetArn)}
 		attribs = append(attribs, attr)
 
 		result := app.GetQueueAttributesResult{Attrs: attribs}
@@ -745,17 +757,44 @@ func GetQueueAttributes(w http.ResponseWriter, req *http.Request) {
 		log.Println("Get Queue URL:", queueName, ", queue does not exist!!!")
 		createErrorResponse(w, req, "QueueNotFound")
 	}
+	app.SyncQueues.RUnlock()
 }
 
 func SetQueueAttributes(w http.ResponseWriter, req *http.Request) {
-	log.Println("setQueueAttributes was called but it's not implemented")
-	respStruct := app.SetQueueAttributesResponse{"http://queue.amazonaws.com/doc/2012-11-05/", app.ResponseMetadata{RequestId: "00000000-0000-0000-0000-000000000000"}}
-	enc := xml.NewEncoder(w)
-	enc.Indent("  ", "    ")
-	if err := enc.Encode(respStruct); err != nil {
-		log.Printf("error: %v\n", err)
-		createErrorResponse(w, req, "GeneralError")
+	// Sent response type
+	w.Header().Set("Content-Type", "application/xml")
+
+	queueUrl := getQueueFromPath(req.FormValue("QueueUrl"), req.URL.String())
+
+	queueName := ""
+	if queueUrl == "" {
+		vars := mux.Vars(req)
+		queueName = vars["queueName"]
+	} else {
+		uriSegments := strings.Split(queueUrl, "/")
+		queueName = uriSegments[len(uriSegments)-1]
 	}
+
+	log.Println("Set Queue Attributes:", queueName)
+	app.SyncQueues.Lock()
+	if queue, ok := app.SyncQueues.Queues[queueName]; ok {
+		if err := validateAndSetQueueAttributes(queue, req.Form); err != nil {
+			createErrorResponse(w, req, err.Error())
+			app.SyncQueues.Unlock()
+			return
+		}
+
+		respStruct := app.SetQueueAttributesResponse{"http://queue.amazonaws.com/doc/2012-11-05/", app.ResponseMetadata{RequestId: "00000000-0000-0000-0000-000000000000"}}
+		enc := xml.NewEncoder(w)
+		enc.Indent("  ", "    ")
+		if err := enc.Encode(respStruct); err != nil {
+			log.Printf("error: %v\n", err)
+		}
+	} else {
+		log.Println("Get Queue URL:", queueName, ", queue does not exist!!!")
+		createErrorResponse(w, req, "QueueNotFound")
+	}
+	app.SyncQueues.Unlock()
 }
 
 func getMessageResult(m *app.Message) *app.ResultMessage {

--- a/app/gosqs/queue_attributes.go
+++ b/app/gosqs/queue_attributes.go
@@ -26,38 +26,53 @@ var (
 	}
 )
 
-// validateQueueAttributes applies the requested queue attributes to the given
+// validateAndSetQueueAttributes applies the requested queue attributes to the given
 // queue.
-// TODO Currently it only supports VisibilityTimeout and RedrivePolicy attributes.
-func validateQueueAttributes(q *app.Queue, u url.Values) error {
+// TODO Currently it only supports VisibilityTimeout, RedrivePolicy and ReceiveMessageWaitTimeSeconds  attributes.
+func validateAndSetQueueAttributes(q *app.Queue, u url.Values) error {
 	attr := extractQueueAttributes(u)
 	visibilityTimeout, _ := strconv.Atoi(attr["VisibilityTimeout"])
 	if visibilityTimeout != 0 {
 		q.TimeoutSecs = visibilityTimeout
 	}
-	redrivePolicy := attr["RedrivePolicy"]
-	if redrivePolicy != "" {
-		str := struct {
+	receiveWaitTime, _ := strconv.Atoi(attr["ReceiveMessageWaitTimeSeconds"])
+	if receiveWaitTime != 0 {
+		q.ReceiveWaitTimeSecs = receiveWaitTime
+	}
+	strRedrivePolicy := attr["RedrivePolicy"]
+	if strRedrivePolicy != "" {
+		// support both int and string maxReceiveCount (Amazon clients use string)
+		redrivePolicy1 := struct {
 			MaxReceiveCount     int    `json:"maxReceiveCount"`
 			DeadLetterTargetArn string `json:"deadLetterTargetArn"`
 		}{}
-		err := json.Unmarshal([]byte(redrivePolicy), &str)
-		if err != nil {
+		redrivePolicy2 := struct {
+			MaxReceiveCount     string `json:"maxReceiveCount"`
+			DeadLetterTargetArn string `json:"deadLetterTargetArn"`
+		}{}
+		err1 := json.Unmarshal([]byte(strRedrivePolicy), &redrivePolicy1)
+		err2 := json.Unmarshal([]byte(strRedrivePolicy), &redrivePolicy2)
+		maxReceiveCount := redrivePolicy1.MaxReceiveCount
+		deadLetterQueueArn := redrivePolicy1.DeadLetterTargetArn
+		if err1 != nil && err2 != nil {
 			return ErrInvalidAttributeValue
+		} else if err1 != nil {
+			maxReceiveCount, _ = strconv.Atoi(redrivePolicy2.MaxReceiveCount)
+			deadLetterQueueArn = redrivePolicy2.DeadLetterTargetArn
 		}
 
-		if (str.DeadLetterTargetArn != "" && str.MaxReceiveCount == 0) ||
-			(str.DeadLetterTargetArn == "" && str.MaxReceiveCount != 0) {
+		if (deadLetterQueueArn != "" && maxReceiveCount == 0) ||
+			(deadLetterQueueArn == "" && maxReceiveCount != 0) {
 			return ErrInvalidParameterValue
 		}
-		dlt := strings.Split(str.DeadLetterTargetArn, ":")
+		dlt := strings.Split(deadLetterQueueArn, ":")
 		deadLetterQueueName := dlt[len(dlt)-1]
 		deadLetterQueue, ok := app.SyncQueues.Queues[deadLetterQueueName]
 		if !ok {
 			return ErrInvalidParameterValue
 		}
 		q.DeadLetterQueue = deadLetterQueue
-		q.MaxReceiveCount = str.MaxReceiveCount
+		q.MaxReceiveCount = maxReceiveCount
 	}
 
 	return nil

--- a/app/gosqs/queue_attributes_test.go
+++ b/app/gosqs/queue_attributes_test.go
@@ -22,14 +22,17 @@ func TestApplyQueueAttributes(t *testing.T) {
 		u.Add("Attribute.2.Value", "60")
 		u.Add("Attribute.3.Name", "Policy")
 		u.Add("Attribute.4.Name", "RedrivePolicy")
-		u.Add("Attribute.4.Value", `{"maxReceiveCount": 4, "deadLetterTargetArn":"arn:aws:sqs::000000000000:failed-messages"}`)
-		if err := validateQueueAttributes(q, u); err != nil {
+		u.Add("Attribute.4.Value", `{"maxReceiveCount": "4", "deadLetterTargetArn":"arn:aws:sqs::000000000000:failed-messages"}`)
+		u.Add("Attribute.5.Name", "ReceiveMessageWaitTimeSeconds")
+		u.Add("Attribute.5.Value", "20")
+		if err := validateAndSetQueueAttributes(q, u); err != nil {
 			t.Fatalf("expected nil, got %s", err)
 		}
 		expected := &app.Queue{
-			TimeoutSecs:     60,
-			MaxReceiveCount: 4,
-			DeadLetterQueue: deadLetterQueue,
+			TimeoutSecs:         60,
+			ReceiveWaitTimeSecs: 20,
+			MaxReceiveCount:     4,
+			DeadLetterQueue:     deadLetterQueue,
 		}
 		if ok := reflect.DeepEqual(q, expected); !ok {
 			t.Fatalf("expected %+v, got %+v", expected, q)
@@ -39,8 +42,8 @@ func TestApplyQueueAttributes(t *testing.T) {
 		q := &app.Queue{TimeoutSecs: 30}
 		u := url.Values{}
 		u.Add("Attribute.1.Name", "RedrivePolicy")
-		u.Add("Attribute.1.Value", `{"maxReceiveCount": 4}`)
-		err := validateQueueAttributes(q, u)
+		u.Add("Attribute.1.Value", `{"maxReceiveCount": "4"}`)
+		err := validateAndSetQueueAttributes(q, u)
 		if err != ErrInvalidParameterValue {
 			t.Fatalf("expected %s, got %s", ErrInvalidParameterValue, err)
 		}
@@ -50,7 +53,7 @@ func TestApplyQueueAttributes(t *testing.T) {
 		u := url.Values{}
 		u.Add("Attribute.1.Name", "RedrivePolicy")
 		u.Add("Attribute.1.Value", `{invalidinput}`)
-		err := validateQueueAttributes(q, u)
+		err := validateAndSetQueueAttributes(q, u)
 		if err != ErrInvalidAttributeValue {
 			t.Fatalf("expected %s, got %s", ErrInvalidAttributeValue, err)
 		}

--- a/app/sqs.go
+++ b/app/sqs.go
@@ -38,13 +38,14 @@ type MessageAttributeValue struct {
 }
 
 type Queue struct {
-	Name            string
-	URL             string
-	Arn             string
-	TimeoutSecs     int
-	Messages        []Message
-	DeadLetterQueue *Queue
-	MaxReceiveCount int
+	Name                string
+	URL                 string
+	Arn                 string
+	TimeoutSecs         int
+	ReceiveWaitTimeSecs int
+	Messages            []Message
+	DeadLetterQueue     *Queue
+	MaxReceiveCount     int
 }
 
 var SyncQueues = struct {


### PR DESCRIPTION
Main features in this PR:

- Implement SQS ReceiveMessageWaitTimeSeconds attribute and obeys it in ReceiveMessage
- Adds support to subscribe to SNS with SQS ARN
- Implement SetQueueAttributes (supports VisibilityTimeout, RedrivePolicy and ReceiveMessageWaitTimeSeconds)
- Allowing to config ReceiveMessageWaitTimeSeconds for queues in config file
- Added RedrivePolicy to GetQueueAttributes

Subscribe supports both URL and ARN endpoints and Publish will work in both cases, but I've changed the subscriptions that are created with config file to use ARN as this is how AWS configure subscriptions.
Made SetQueueAttributes  and CreateQueue to support RedrivePolicy in AWS's format (maxReceiveCount is string) but left the support for passing maxReceiveCount as int anyway.

It closes #140 #145 #30