### PR TITLE
Resolving deadlock issue with `WaitTimeSeconds` parameter

### DIFF
--- a/app/cmd/goaws.go
+++ b/app/cmd/goaws.go
@@ -8,9 +8,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/p4tin/goaws/app/conf"
-	"github.com/p4tin/goaws/app/gosqs"
-	"github.com/p4tin/goaws/app/router"
+	"github.com/archa347/goaws/app/conf"
+	"github.com/archa347/goaws/app/gosqs"
+	"github.com/archa347/goaws/app/router"
 )
 
 func main() {

--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/ghodss/yaml"
-	"github.com/p4tin/goaws/app"
-	"github.com/p4tin/goaws/app/common"
+	"github.com/archa347/goaws/app"
+	"github.com/archa347/goaws/app/common"
 )
 
 var envs map[string]app.Environment

--- a/app/conf/config_test.go
+++ b/app/conf/config_test.go
@@ -3,7 +3,7 @@ package conf
 import (
 	"testing"
 
-	"github.com/p4tin/goaws/app"
+	"github.com/archa347/goaws/app"
 )
 
 func TestConfig_NoQueuesOrTopics(t *testing.T) {

--- a/app/gosns/gosns.go
+++ b/app/gosns/gosns.go
@@ -11,8 +11,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/p4tin/goaws/app"
-	"github.com/p4tin/goaws/app/common"
+	"github.com/archa347/goaws/app"
+	"github.com/archa347/goaws/app/common"
 )
 
 func init() {

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -336,8 +336,9 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 	loops := waitTimeSeconds * 10
 	for loops > 0 {
 		app.SyncQueues.Lock()
-		found := len(app.SyncQueues.Queues[queueName].Messages)-numberOfHiddenMessagesInQueue(*app.SyncQueues.Queues[queueName]) != 0
+		foundMessages := len(app.SyncQueues.Queues[queueName].Messages)
 		app.SyncQueues.Unlock()
+		found := foundMessages-numberOfHiddenMessagesInQueue(*app.SyncQueues.Queues[queueName]) != 0
 		if !found {
 			time.Sleep(100 * time.Millisecond)
 			loops--

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -12,8 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gorilla/mux"
-	"github.com/p4tin/goaws/app"
-	"github.com/p4tin/goaws/app/common"
+	"github.com/archa347/goaws/app"
+	"github.com/archa347/goaws/app/common"
 )
 
 func init() {

--- a/app/gosqs/gosqs_test.go
+++ b/app/gosqs/gosqs_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/p4tin/goaws/app"
+	"github.com/archa347/goaws/app"
 )
 
 func TestListQueues_POST_NoQueues(t *testing.T) {

--- a/app/gosqs/message_attributes.go
+++ b/app/gosqs/message_attributes.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/p4tin/goaws/app"
+	"github.com/archa347/goaws/app"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/app/gosqs/queue_attributes.go
+++ b/app/gosqs/queue_attributes.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/p4tin/goaws/app"
+	"github.com/archa347/goaws/app"
 )
 
 var (

--- a/app/gosqs/queue_attributes_test.go
+++ b/app/gosqs/queue_attributes_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/p4tin/goaws/app"
+	"github.com/archa347/goaws/app"
 )
 
 func TestApplyQueueAttributes(t *testing.T) {

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gorilla/mux"
-	sns "github.com/p4tin/goaws/app/gosns"
-	sqs "github.com/p4tin/goaws/app/gosqs"
+	sns "github.com/archa347/goaws/app/gosns"
+	sqs "github.com/archa347/goaws/app/gosqs"
 )
 
 // New returns a new router

--- a/app/servertest/server.go
+++ b/app/servertest/server.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/p4tin/goaws/app/router"
+	"github.com/archa347/goaws/app/router"
 )
 
 // Server is a fake SQS / SNS server for testing purposes.

--- a/app/servertest/server_test.go
+++ b/app/servertest/server_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
-	"github.com/p4tin/goaws/app/servertest"
+	"github.com/archa347/goaws/app/servertest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
The function `numberOfHiddenMessageInQueue` also tries to acquire a lock with `app.SyncQueues.Lock()`, thus using the `WaitTimeSeconds` immediately causes deadlock as it tries to acquire the lock twice.  This attempts to resolve this issue.