### PR TITLE
ISSUE-154: Rename Message TimeStamp Property

### DIFF
--- a/app/gosns/gosns.go
+++ b/app/gosns/gosns.go
@@ -296,7 +296,7 @@ type TopicMessage struct {
 	TopicArn  string
 	Subject   string
 	Message   string
-	TimeStamp string
+	Timestamp string
 }
 
 func CreateMessageBody(msg string, subject string, topicArn string, protocol string, messageStructure string) ([]byte, error) {
@@ -319,7 +319,7 @@ func CreateMessageBody(msg string, subject string, topicArn string, protocol str
 	message.MessageId = msgId
 	message.TopicArn = topicArn
 	t := time.Now()
-	message.TimeStamp = fmt.Sprintln(t.Format("2006-01-02T15:04:05:001Z"))
+	message.Timestamp = fmt.Sprintln(t.Format("2006-01-02T15:04:05.001Z"))
 
 	byteMsg, _ := json.Marshal(message)
 	return byteMsg, nil


### PR DESCRIPTION
Rename `TimeStamp` Message property to `Timestamp` to be consistent with the associated AWS SNS Message Body property.