### PR TITLE
Remove newline from SNS Message timestamp

### DIFF
--- a/app/gosns/gosns.go
+++ b/app/gosns/gosns.go
@@ -319,7 +319,7 @@ func CreateMessageBody(msg string, subject string, topicArn string, protocol str
 	message.MessageId = msgId
 	message.TopicArn = topicArn
 	t := time.Now()
-	message.Timestamp = fmt.Sprintln(t.Format("2006-01-02T15:04:05.001Z"))
+	message.Timestamp = fmt.Sprint(t.Format("2006-01-02T15:04:05.001Z"))
 
 	byteMsg, _ := json.Marshal(message)
 	return byteMsg, nil


### PR DESCRIPTION
Remove the `\n` that was appended to the end of the `Timestamp` SNS Message property.