### PR TITLE
FIFO Support

### DIFF
--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -62,7 +62,15 @@ func LoadYamlConfig(filename string, env string) []string {
 	for _, queue := range envs[env].Queues {
 		queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port + "/queue/" + queue.Name
 		queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":000000000000:" + queue.Name
-		app.SyncQueues.Queues[queue.Name] = &app.Queue{Name: queue.Name, TimeoutSecs: 30, Arn: queueArn, URL: queueUrl, ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds}
+		app.SyncQueues.Queues[queue.Name] = &app.Queue{
+			Name:                queue.Name,
+			TimeoutSecs:         30,
+			Arn:                 queueArn,
+			URL:                 queueUrl,
+			ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds
+			IsFIFO:              app.HasFIFOQueueName(queue.Name),
+			FIFOSequenceNumbers: make(map[string]int),
+		}
 	}
 
 	for _, topic := range envs[env].Topics {
@@ -76,7 +84,14 @@ func LoadYamlConfig(filename string, env string) []string {
 				//Queue does not exist yet, create it.
 				queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port + "/queue/" + subs.QueueName
 				queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":000000000000:" + subs.QueueName
-				app.SyncQueues.Queues[subs.QueueName] = &app.Queue{Name: subs.QueueName, TimeoutSecs: 30, Arn: queueArn, URL: queueUrl}
+				app.SyncQueues.Queues[subs.QueueName] = &app.Queue{
+					Name:                subs.QueueName,
+					TimeoutSecs:         30,
+					Arn:                 queueArn,
+					URL:                 queueUrl,
+					IsFIFO:              app.HasFIFOQueueName(subs.QueueName),
+					FIFOSequenceNumbers: make(map[string]int),
+				}
 			}
 			qArn := app.SyncQueues.Queues[subs.QueueName].Arn
 			newSub := &app.Subscription{EndPoint: qArn, Protocol: "sqs", TopicArn: topicArn, Raw: subs.Raw}

--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -67,8 +67,8 @@ func LoadYamlConfig(filename string, env string) []string {
 			TimeoutSecs:         30,
 			Arn:                 queueArn,
 			URL:                 queueUrl,
-			ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds
-			IsFIFO:           app.HasFIFOQueueName(queue.Name),
+			ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds,
+			IsFIFO:              app.HasFIFOQueueName(queue.Name),
 		}
 	}
 

--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -68,8 +68,7 @@ func LoadYamlConfig(filename string, env string) []string {
 			Arn:                 queueArn,
 			URL:                 queueUrl,
 			ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds
-			IsFIFO:              app.HasFIFOQueueName(queue.Name),
-			FIFOSequenceNumbers: make(map[string]int),
+			IsFIFO:           app.HasFIFOQueueName(queue.Name),
 		}
 	}
 
@@ -85,12 +84,11 @@ func LoadYamlConfig(filename string, env string) []string {
 				queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port + "/queue/" + subs.QueueName
 				queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":000000000000:" + subs.QueueName
 				app.SyncQueues.Queues[subs.QueueName] = &app.Queue{
-					Name:                subs.QueueName,
-					TimeoutSecs:         30,
-					Arn:                 queueArn,
-					URL:                 queueUrl,
-					IsFIFO:              app.HasFIFOQueueName(subs.QueueName),
-					FIFOSequenceNumbers: make(map[string]int),
+					Name:        subs.QueueName,
+					TimeoutSecs: 30,
+					Arn:         queueArn,
+					URL:         queueUrl,
+					IsFIFO:      app.HasFIFOQueueName(subs.QueueName),
 				}
 			}
 			qArn := app.SyncQueues.Queues[subs.QueueName].Arn

--- a/app/conf/config_test.go
+++ b/app/conf/config_test.go
@@ -57,13 +57,8 @@ func TestConfig_CreateQueuesTopicsAndSubscriptions(t *testing.T) {
 		t.Errorf("Expected two topics to be in the sns topics but got %d\n", numTopics)
 	}
 
-	numSubscriptions := 2
-	if numSubscriptions != 2 {
-		t.Errorf("Expected two Subscriptions to be in the environment but got %d\n", numTopics)
-	}
-
 	receiveWaitTime := app.SyncQueues.Queues["local-queue2"].ReceiveWaitTimeSecs
 	if receiveWaitTime != 20 {
-		t.Errorf("Expected local-queue2 Queue to be configured with ReceiveMessageWaitTimeSeconds: 20 but got %s\n", receiveWaitTime)
+		t.Errorf("Expected local-queue2 Queue to be configured with ReceiveMessageWaitTimeSeconds: 20 but got %d\n", receiveWaitTime)
 	}
 }

--- a/app/conf/config_test.go
+++ b/app/conf/config_test.go
@@ -15,20 +15,20 @@ func TestConfig_NoQueuesOrTopics(t *testing.T) {
 
 	numQueues := len(envs[env].Queues)
 	if numQueues != 0 {
-		t.Errorf("Expected zero queues to be in the environment but got %s\n", numQueues)
+		t.Errorf("Expected zero queues to be in the environment but got %d\n", numQueues)
 	}
 	numQueues = len(app.SyncQueues.Queues)
 	if numQueues != 0 {
-		t.Errorf("Expected zero queues to be in the sqs topics but got %s\n", numQueues)
+		t.Errorf("Expected zero queues to be in the sqs topics but got %d\n", numQueues)
 	}
 
 	numTopics := len(envs[env].Topics)
 	if numTopics != 0 {
-		t.Errorf("Expected zero topics to be in the environment but got %s\n", numTopics)
+		t.Errorf("Expected zero topics to be in the environment but got %d\n", numTopics)
 	}
 	numTopics = len(app.SyncTopics.Topics)
 	if numTopics != 0 {
-		t.Errorf("Expected zero topics to be in the sns topics but got %s\n", numTopics)
+		t.Errorf("Expected zero topics to be in the sns topics but got %d\n", numTopics)
 	}
 }
 
@@ -41,25 +41,25 @@ func TestConfig_CreateQueuesTopicsAndSubscriptions(t *testing.T) {
 
 	numQueues := len(envs[env].Queues)
 	if numQueues != 3 {
-		t.Errorf("Expected three queues to be in the environment but got %s\n", numQueues)
+		t.Errorf("Expected three queues to be in the environment but got %d\n", numQueues)
 	}
 	numQueues = len(app.SyncQueues.Queues)
 	if numQueues != 5 {
-		t.Errorf("Expected five queues to be in the sqs topics but got %s\n", numQueues)
+		t.Errorf("Expected five queues to be in the sqs topics but got %d\n", numQueues)
 	}
 
 	numTopics := len(envs[env].Topics)
 	if numTopics != 2 {
-		t.Errorf("Expected two topics to be in the environment but got %s\n", numTopics)
+		t.Errorf("Expected two topics to be in the environment but got %d\n", numTopics)
 	}
 	numTopics = len(app.SyncTopics.Topics)
 	if numTopics != 2 {
-		t.Errorf("Expected two topics to be in the sns topics but got %s\n", numTopics)
+		t.Errorf("Expected two topics to be in the sns topics but got %d\n", numTopics)
 	}
 
 	numSubscriptions := 2
 	if numSubscriptions != 2 {
-		t.Errorf("Expected two Subscriptions to be in the environment but got %s\n", numTopics)
+		t.Errorf("Expected two Subscriptions to be in the environment but got %d\n", numTopics)
 	}
 
 	receiveWaitTime := app.SyncQueues.Queues["local-queue2"].ReceiveWaitTimeSecs

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -394,12 +394,14 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 			msg.ReceiptTime = time.Now()
 			msg.VisibilityTimeout = time.Now().Add(time.Duration(app.SyncQueues.Queues[queueName].TimeoutSecs) * time.Second)
 
-			// If we got message here it means we have not processed it yet, so get next
-			if app.SyncQueues.Queues[queueName].IsLocked(msg.GroupID) {
-				continue
+			if app.SyncQueues.Queues[queueName].IsFIFO {
+				// If we got message here it means we have not processed it yet, so get next
+				if app.SyncQueues.Queues[queueName].IsLocked(msg.GroupID) {
+					continue
+				}
+				// Otherwise lock message for group ID
+				app.SyncQueues.Queues[queueName].LockGroup(msg.GroupID)
 			}
-			// Otherwise lock message for group ID
-			app.SyncQueues.Queues[queueName].LockGroup(msg.GroupID)
 
 			message = append(message, getMessageResult(msg))
 

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -400,7 +400,7 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 				continue
 			}
 			// Otherwise lock message for group ID
-			app.SyncQueues.Queues[queueName].FIFOMessages[msg.GroupID] = *msg
+			app.SyncQueues.Queues[queueName].FIFOMessages[msg.GroupID] = 0
 
 			message = append(message, getMessageResult(msg))
 

--- a/app/sqs.go
+++ b/app/sqs.go
@@ -50,7 +50,7 @@ type Queue struct {
 	DeadLetterQueue     *Queue
 	MaxReceiveCount     int
 	IsFIFO              bool
-	FIFOMessages        map[string]Message
+	FIFOMessages        map[string]int
 	FIFOSequenceNumbers map[string]int
 }
 

--- a/app/sqs.go
+++ b/app/sqs.go
@@ -71,3 +71,22 @@ func (q *Queue) NextSequenceNumber(groupId string) string {
 	q.FIFOSequenceNumbers[groupId]++
 	return strconv.Itoa(q.FIFOSequenceNumbers[groupId])
 }
+
+func (q *Queue) IsLocked(groupId string) bool {
+	_, ok := q.FIFOMessages[groupId]
+	return ok
+}
+
+func (q *Queue) LockGroup(groupId string) {
+	if _, ok := q.FIFOMessages[groupId]; !ok {
+		q.FIFOMessages = map[string]int{
+			groupId: 0,
+		}
+	}
+}
+
+func (q *Queue) UnlockGroup(groupId string) {
+	if _, ok := q.FIFOMessages[groupId]; ok {
+		delete(q.FIFOMessages, groupId)
+	}
+}

--- a/app/sqs.go
+++ b/app/sqs.go
@@ -65,7 +65,9 @@ func HasFIFOQueueName(queueName string) bool {
 
 func (q *Queue) NextSequenceNumber(groupId string) string {
 	if _, ok := q.FIFOSequenceNumbers[groupId]; !ok {
-		q.FIFOSequenceNumbers[groupId] = 0
+		q.FIFOSequenceNumbers = map[string]int{
+			groupId: 0,
+		}
 	}
 
 	q.FIFOSequenceNumbers[groupId]++

--- a/app/sqs_messages.go
+++ b/app/sqs_messages.go
@@ -28,6 +28,7 @@ type SendMessageResult struct {
 	MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes"`
 	MD5OfMessageBody       string `xml:"MD5OfMessageBody"`
 	MessageId              string `xml:"MessageId"`
+	SequenceNumber         string `xml:"SequenceNumber"`
 }
 
 type SendMessageResponse struct {
@@ -88,6 +89,7 @@ type SendMessageBatchResultEntry struct {
 	MessageId              string `xml:"MessageId"`
 	MD5OfMessageBody       string `xml:"MD5OfMessageBody,omitempty"`
 	MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes,omitempty"`
+	SequenceNumber         string `xml:"SequenceNumber"`
 }
 
 type BatchResultErrorEntry struct {


### PR DESCRIPTION
This is backward compatible PR to support FIFO queues. If queue name has `.fifo` suffix it will be treated as FIFO. 

- receive a message from the same groupId will lock it and won't allow other consumers to receive it
- visibility timeout and removing message will unlock group