### PR TITLE
option for QueueAttributeDefaults in config

### DIFF
--- a/app/common.go
+++ b/app/common.go
@@ -16,16 +16,22 @@ type EnvQueue struct {
 	ReceiveMessageWaitTimeSeconds int
 }
 
+type EnvQueueAttributes struct {
+	VisibilityTimeout             int
+	ReceiveMessageWaitTimeSeconds int
+}
+
 type Environment struct {
-	Host        string
-	Port        string
-	SqsPort     string
-	SnsPort     string
-	Region      string
-	LogMessages bool
-	LogFile     string
-	Topics      []EnvTopic
-	Queues      []EnvQueue
+	Host                   string
+	Port                   string
+	SqsPort                string
+	SnsPort                string
+	Region                 string
+	LogMessages            bool
+	LogFile                string
+	Topics                 []EnvTopic
+	Queues                 []EnvQueue
+	QueueAttributeDefaults EnvQueueAttributes
 }
 
 var CurrentEnvironment Environment

--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -57,14 +57,23 @@ func LoadYamlConfig(filename string, env string) []string {
 		}
 	}
 
+	if app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout == 0 {
+		app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout = 30
+	}
+
 	app.SyncQueues.Lock()
 	app.SyncTopics.Lock()
 	for _, queue := range envs[env].Queues {
 		queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port + "/queue/" + queue.Name
 		queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":000000000000:" + queue.Name
+
+		if queue.ReceiveMessageWaitTimeSeconds == 0 {
+			queue.ReceiveMessageWaitTimeSeconds = app.CurrentEnvironment.QueueAttributeDefaults.ReceiveMessageWaitTimeSeconds
+		}
+
 		app.SyncQueues.Queues[queue.Name] = &app.Queue{
 			Name:                queue.Name,
-			TimeoutSecs:         30,
+			TimeoutSecs:         app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout,
 			Arn:                 queueArn,
 			URL:                 queueUrl,
 			ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds,
@@ -84,11 +93,12 @@ func LoadYamlConfig(filename string, env string) []string {
 				queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port + "/queue/" + subs.QueueName
 				queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":000000000000:" + subs.QueueName
 				app.SyncQueues.Queues[subs.QueueName] = &app.Queue{
-					Name:        subs.QueueName,
-					TimeoutSecs: 30,
-					Arn:         queueArn,
-					URL:         queueUrl,
-					IsFIFO:      app.HasFIFOQueueName(subs.QueueName),
+					Name:                subs.QueueName,
+					TimeoutSecs:         app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout,
+					Arn:                 queueArn,
+					URL:                 queueUrl,
+					ReceiveWaitTimeSecs: app.CurrentEnvironment.QueueAttributeDefaults.ReceiveMessageWaitTimeSeconds,
+					IsFIFO:              app.HasFIFOQueueName(subs.QueueName),
 				}
 			}
 			qArn := app.SyncQueues.Queues[subs.QueueName].Arn

--- a/app/conf/config_test.go
+++ b/app/conf/config_test.go
@@ -56,8 +56,44 @@ func TestConfig_CreateQueuesTopicsAndSubscriptions(t *testing.T) {
 	if numTopics != 2 {
 		t.Errorf("Expected two topics to be in the sns topics but got %d\n", numTopics)
 	}
+}
 
-	receiveWaitTime := app.SyncQueues.Queues["local-queue2"].ReceiveWaitTimeSecs
+func TestConfig_QueueAttributes(t *testing.T) {
+	env := "Local"
+	port := LoadYamlConfig("./mock-data/mock-config.yaml", env)
+	if port[0] != "4100" {
+		t.Errorf("Expected port number 4100 but got %s\n", port)
+	}
+
+	receiveWaitTime := app.SyncQueues.Queues["local-queue1"].ReceiveWaitTimeSecs
+	if receiveWaitTime != 10 {
+		t.Errorf("Expected local-queue1 Queue to be configured with ReceiveMessageWaitTimeSeconds: 10 but got %d\n", receiveWaitTime)
+	}
+	timeoutSecs := app.SyncQueues.Queues["local-queue1"].TimeoutSecs
+	if timeoutSecs != 10 {
+		t.Errorf("Expected local-queue1 Queue to be configured with VisibilityTimeout: 10 but got %d\n", timeoutSecs)
+	}
+
+	receiveWaitTime = app.SyncQueues.Queues["local-queue2"].ReceiveWaitTimeSecs
+	if receiveWaitTime != 20 {
+		t.Errorf("Expected local-queue2 Queue to be configured with ReceiveMessageWaitTimeSeconds: 20 but got %d\n", receiveWaitTime)
+	}
+}
+
+func TestConfig_NoQueueAttributeDefaults(t *testing.T) {
+	env := "NoQueueAttributeDefaults"
+	LoadYamlConfig("./mock-data/mock-config.yaml", env)
+
+	receiveWaitTime := app.SyncQueues.Queues["local-queue1"].ReceiveWaitTimeSecs
+	if receiveWaitTime != 0 {
+		t.Errorf("Expected local-queue1 Queue to be configured with ReceiveMessageWaitTimeSeconds: 0 but got %d\n", receiveWaitTime)
+	}
+	timeoutSecs := app.SyncQueues.Queues["local-queue1"].TimeoutSecs
+	if timeoutSecs != 30 {
+		t.Errorf("Expected local-queue1 Queue to be configured with VisibilityTimeout: 30 but got %d\n", timeoutSecs)
+	}
+
+	receiveWaitTime = app.SyncQueues.Queues["local-queue2"].ReceiveWaitTimeSecs
 	if receiveWaitTime != 20 {
 		t.Errorf("Expected local-queue2 Queue to be configured with ReceiveMessageWaitTimeSeconds: 20 but got %d\n", receiveWaitTime)
 	}

--- a/app/conf/goaws.yaml
+++ b/app/conf/goaws.yaml
@@ -9,6 +9,9 @@ Local:                              # Environment name that can be passed on the
   Region: local-01
   LogMessages: true                 # Log messages (true/false)
   LogFile: ./goaws_messages.log  # Log filename (for message logging
+  QueueAttributeDefaults:           # default attributes for all queues
+    VisibilityTimeout: 30              # message visibility timeout
+    ReceiveMessageWaitTimeSeconds: 0   # receive message max wait time
   Queues:                           # List of queues to create at startup
     - Name: local-queue1                # Queue name
     - Name: local-queue2                # Queue name

--- a/app/conf/mock-data/mock-config.yaml
+++ b/app/conf/mock-data/mock-config.yaml
@@ -4,6 +4,9 @@ Local:                              # Environment name that can be passed on the
   Port: 4100                        # port to listen on.
   LogMessages: true                 # Log messages (true/false)
   LogFile: ./goaws_messages.log     # Log filename (for message logging
+  QueueAttributeDefaults:           # default attributes for all queues
+    VisibilityTimeout: 10              # message visibility timeout
+    ReceiveMessageWaitTimeSeconds: 10  # receive message max wait time
   Queues:                           # List of queues to create at startup
     - Name: local-queue1                # Queue name
     - Name: local-queue2                # Queue name
@@ -25,3 +28,13 @@ NoQueuesOrTopics:                                # Another environment
   LogFile: ./goaws_messages.log
   Region: eu-west-1
 
+NoQueueAttributeDefaults:
+  Host: localhost
+  Port: 4100
+  LogMessages: true
+  LogFile: ./goaws_messages.log
+  Region: eu-west-1
+  Queues:
+    - Name: local-queue1
+    - Name: local-queue2
+      ReceiveMessageWaitTimeSeconds: 20

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -113,11 +113,12 @@ func CreateQueue(w http.ResponseWriter, req *http.Request) {
 	if _, ok := app.SyncQueues.Queues[queueName]; !ok {
 		log.Println("Creating Queue:", queueName)
 		queue := &app.Queue{
-			Name:        queueName,
-			URL:         queueUrl,
-			Arn:         queueArn,
-			TimeoutSecs: 30,
-			IsFIFO:      app.HasFIFOQueueName(queueName),
+			Name:                queueName,
+			URL:                 queueUrl,
+			Arn:                 queueArn,
+			TimeoutSecs:         app.CurrentEnvironment.QueueAttributeDefaults.VisibilityTimeout,
+			ReceiveWaitTimeSecs: app.CurrentEnvironment.QueueAttributeDefaults.ReceiveMessageWaitTimeSeconds,
+			IsFIFO:              app.HasFIFOQueueName(queueName),
 		}
 		if err := validateAndSetQueueAttributes(queue, req.Form); err != nil {
 			createErrorResponse(w, req, err.Error())


### PR DESCRIPTION
Added ability to set attributes for all queues in config file

QueueAttributeDefaults:           # default attributes for all queues
    VisibilityTimeout: 30              # message visibility timeout
    ReceiveMessageWaitTimeSeconds: 0   # receive message max wait time
