### PR TITLE
Attaches attributes on raw

### DIFF
--- a/app/gosns/gosns.go
+++ b/app/gosns/gosns.go
@@ -236,9 +236,7 @@ func Publish(w http.ResponseWriter, req *http.Request) {
 	subject := req.FormValue("Subject")
 	messageBody := req.FormValue("Message")
 	messageStructure := req.FormValue("MessageStructure")
-	fmt.Printf("\n\n%+v\n", req.Form)
 	attributes := extractMessageAttributes(req)
-	fmt.Printf("\n\n%+v\n", attributes)
 
 	arnSegments := strings.Split(topicArn, ":")
 	topicName := arnSegments[len(arnSegments)-1]


### PR DESCRIPTION
the emulator currently ignores any message attributes, even when the subscription is raw. AWS SNS however includes message attributes when the subscription is raw. https://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html

with this PR, publishing with message attributes and processing those attributes in the queue now work seamlessly with the AWS-SDK for go