### PR TITLE
adds message attributes to publish that attach to the sqs attributes on raw

### DIFF
--- a/app/gosns/gosns_test.go
+++ b/app/gosns/gosns_test.go
@@ -1,13 +1,14 @@
 package gosns
 
 import (
-	"github.com/p4tin/goaws/app"
-	"github.com/p4tin/goaws/app/common"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/p4tin/goaws/app"
+	"github.com/p4tin/goaws/app/common"
 )
 
 func TestListTopicshandler_POST_NoTopics(t *testing.T) {
@@ -221,6 +222,7 @@ func TestPublishHandler_POST_FilterPolicyPassesTheMessage(t *testing.T) {
 	form.Add("TopicArn", topicArn)
 	form.Add("Message", "TestMessage1")
 	form.Add("MessageAttributes.entry.1.Name", "foo")              // special format of parameter for MessageAttribute
+	form.Add("MessageAttributes.entry.1.Value.DataType", "String") // Datatype must be specified for proper parsing by aws
 	form.Add("MessageAttributes.entry.1.Value.StringValue", "bar") // we actually sent attribute `foo` to be equal `baz`
 	req.PostForm = form
 

--- a/app/sns_test.go
+++ b/app/sns_test.go
@@ -1,41 +1,49 @@
 package app
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestFilterPolicy_IsSatisfiedBy(t *testing.T) {
 	var tests = []struct {
 		filterPolicy      *FilterPolicy
-		messageAttributes *TopicMessageAttributes
+		messageAttributes map[string]MessageAttributeValue
 		expected          bool
 	}{
 		{
 			&FilterPolicy{"foo": {"bar"}},
-			&TopicMessageAttributes{"foo": "bar"},
+			map[string]MessageAttributeValue{"foo": MessageAttributeValue{DataType: "String", Value: "bar"}},
 			true,
 		},
 		{
 			&FilterPolicy{"foo": {"bar", "xyz"}},
-			&TopicMessageAttributes{"foo": "xyz"},
+			map[string]MessageAttributeValue{"foo": MessageAttributeValue{DataType: "String", Value: "xyz"}},
 			true,
 		},
 		{
 			&FilterPolicy{"foo": {"bar", "xyz"}, "abc": {"def"}},
-			&TopicMessageAttributes{"foo": "xyz", "abc": "def"},
+			map[string]MessageAttributeValue{"foo": MessageAttributeValue{DataType: "String", Value: "xyz"},
+				"abc": MessageAttributeValue{DataType: "String", Value: "def"}},
 			true,
 		},
 		{
 			&FilterPolicy{"foo": {"bar"}},
-			&TopicMessageAttributes{"foo": "baz"},
+			map[string]MessageAttributeValue{"foo": MessageAttributeValue{DataType: "String", Value: "baz"}},
 			false,
 		},
 		{
 			&FilterPolicy{"foo": {"bar"}},
-			&TopicMessageAttributes{},
+			map[string]MessageAttributeValue{},
 			false,
 		},
 		{
 			&FilterPolicy{"foo": {"bar"}, "abc": {"def"}},
-			&TopicMessageAttributes{"foo": "bar"},
+			map[string]MessageAttributeValue{"foo": MessageAttributeValue{DataType: "String", Value: "bar"}},
+			false,
+		},
+		{
+			&FilterPolicy{"foo": {"bar"}},
+			map[string]MessageAttributeValue{"foo": MessageAttributeValue{DataType: "Binary", Value: "bar"}},
 			false,
 		},
 	}


### PR DESCRIPTION
This is a minor improvement of https://github.com/p4tin/goaws/pull/159 which created a functionality that differed from SNS. 

1. DataType is now required for message attributes. This would have led users to create a functional message attribute attachment in the emulator that would have broken on deployed environments
2. The new message attribute helper in the SNS package used a new specific datatype and helper logic that made the helper incompatible with SQS message attributes
3. The filter policy now properly looks for the Data Type with a comment on how to extend the filter policy to provide support other data types that SNS currently supports. For now I have maintained the current functionality of only supporting String based data types. Documentation on that [here](https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html)

4. Last, I have added the main functionality that I needed, which attaches SNS message attributes to the SQS queue when the queue is set to raw. Documentation on that [here](https://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html)