### PR TITLE
fix test, Errorf format %d

### DIFF
--- a/app/conf/config_test.go
+++ b/app/conf/config_test.go
@@ -100,6 +100,6 @@ func TestConfig_NoQueueAttributeDefaults(t *testing.T) {
 
 	filterPolicy := app.SyncTopics.Topics["local-topic1"].Subscriptions[1].FilterPolicy
 	if (*filterPolicy)["foo"][0] != "bar" {
-		t.Errorf("Expected FilterPolicy subscription on local-topic1 to be: bar but got %d\n", (*filterPolicy)["foo"][0])
+		t.Errorf("Expected FilterPolicy subscription on local-topic1 to be: bar but got %s\n", (*filterPolicy)["foo"][0])
 	}
 }


### PR DESCRIPTION
 app/conf/config_test.go:103: Errorf format %d
 has arg (*filterPolicy)["foo"][0] of wrong type
 string