### PR TITLE
Changed the way we get 'dep' command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM golang:alpine as builder
 
 WORKDIR /go/src/github.com/p4tin/goaws
 
-RUN apk add --update --repository https://dl-3.alpinelinux.org/alpine/edge/testing/ dep git
+RUN apk add --update --repository https://dl-3.alpinelinux.org/alpine/edge/testing/ git
+RUN go get github.com/golang/dep/cmd/dep
 
 COPY Gopkg.lock Gopkg.toml app ./
 RUN dep ensure


### PR DESCRIPTION
When trying to build, I was getting the "dep missing" error:
```
root# docker build .
Sending build context to Docker daemon  5.458MB
Step 1/12 : FROM golang:alpine as builder
 ---> 22e024490b47
Step 2/12 : WORKDIR /go/src/github.com/p4tin/goaws
 ---> Using cache
 ---> d894e2d78145
Step 3/12 : RUN apk add --update --repository https://dl-3.alpinelinux.org/alpine/edge/testing/ dep git
 ---> Running in 2892cae3ba78
fetch https://dl-3.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
WARNING: This apk-tools is OLD! Some packages might not function properly.
ERROR: unsatisfiable constraints:
  dep (missing):
    required by: world[dep]
The command '/bin/sh -c apk add --update --repository https://dl-3.alpinelinux.org/alpine/edge/testing/ dep git' returned a non-zero code: 1
```

It seems that `dep` can no longer be installed using `apk`, so lets get it from GIT. I was able to build the Docker image after applying this fix on my machine.