### PR TITLE
SNS, SQS signature check fixes - for AWS SDK

### DIFF
--- a/app/gosns/gosns.go
+++ b/app/gosns/gosns.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/p4tin/goaws/app"
 	"github.com/p4tin/goaws/app/common"
+	"github.com/p4tin/goaws/app/gosqs"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -328,10 +329,10 @@ func Publish(w http.ResponseWriter, req *http.Request) {
 						msg.MessageBody = m
 					} else {
 						msg.MessageAttributes = messageAttributes
+						msg.MD5OfMessageAttributes = gosqs.HashAttributes(messageAttributes)
 						msg.MessageBody = []byte(messageBody)
 					}
 
-					msg.MD5OfMessageAttributes = common.GetMD5Hash("GoAws")
 					msg.MD5OfMessageBody = common.GetMD5Hash(messageBody)
 					msg.Uuid, _ = common.NewUUID()
 					app.SyncQueues.Lock()

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -162,9 +162,11 @@ func SendMessage(w http.ResponseWriter, req *http.Request) {
 
 	log.Println("Putting Message in Queue:", queueName)
 	msg := app.Message{MessageBody: []byte(messageBody)}
-	msg.MD5OfMessageAttributes = hashAttributes(messageAttributes)
+	if len(messageAttributes) > 0 {
+		msg.MessageAttributes = messageAttributes
+		msg.MD5OfMessageAttributes = HashAttributes(messageAttributes)
+	}
 	msg.MD5OfMessageBody = common.GetMD5Hash(messageBody)
-	msg.MessageAttributes = messageAttributes
 	msg.Uuid, _ = common.NewUUID()
 	msg.GroupID = messageGroupID
 
@@ -288,7 +290,7 @@ func SendMessageBatch(w http.ResponseWriter, req *http.Request) {
 		msg := app.Message{MessageBody: []byte(sendEntry.MessageBody)}
 		if len(sendEntry.MessageAttributes) > 0 {
 			msg.MessageAttributes = sendEntry.MessageAttributes
-			msg.MD5OfMessageAttributes = hashAttributes(sendEntry.MessageAttributes)
+			msg.MD5OfMessageAttributes = HashAttributes(sendEntry.MessageAttributes)
 		}
 		msg.MD5OfMessageBody = common.GetMD5Hash(sendEntry.MessageBody)
 		msg.GroupID = sendEntry.MessageGroupId

--- a/app/gosqs/message_attributes.go
+++ b/app/gosqs/message_attributes.go
@@ -66,7 +66,7 @@ func getMessageAttributeResult(a *app.MessageAttributeValue) *app.ResultMessageA
 	}
 }
 
-func hashAttributes(attributes map[string]app.MessageAttributeValue) string {
+func HashAttributes(attributes map[string]app.MessageAttributeValue) string {
 	hasher := md5.New()
 
 	keys := sortedKeys(attributes)


### PR DESCRIPTION
SNS: previous signature genaration msg.MD5OfMessageAttributes = common.GetMD5Hash("GoAws")  caused failing of signature check in AWS SDK so could be simply deleted but I've added signature gen from gosqs.
  
SQS: add MD5OfMessageAttributes only if MessageAttributes not empty - according to logic of AWS SDK signature check failed if MessageAttributes filled and MD5OfMessageAttributes exists.