### PR TITLE
Fix 'slice bounds out of range' in DeleteMessageBatch

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -572,8 +572,8 @@ func DeleteMessageBatch(w http.ResponseWriter, req *http.Request) {
 
 	app.SyncQueues.Lock()
 	if _, ok := app.SyncQueues.Queues[queueName]; ok {
-		for i, msg := range app.SyncQueues.Queues[queueName].Messages {
-			for _, deleteEntry := range deleteEntries {
+		for _, deleteEntry := range deleteEntries {
+			for i, msg := range app.SyncQueues.Queues[queueName].Messages {
 				if msg.ReceiptHandle == deleteEntry.ReceiptHandle {
 					// Unlock messages for the group
 					log.Printf("FIFO Queue %s unlocking group %s:", queueName, msg.GroupID)
@@ -583,6 +583,7 @@ func DeleteMessageBatch(w http.ResponseWriter, req *http.Request) {
 					deleteEntry.Deleted = true
 					deletedEntry := app.DeleteMessageBatchResultEntry{Id: deleteEntry.Id}
 					deletedEntries = append(deletedEntries, deletedEntry)
+					break
 				}
 			}
 		}


### PR DESCRIPTION
There is a bug inside `DeleteMessageBatch` function (issue https://github.com/p4tin/goaws/issues/171):
```
2018/09/21 14:58:01 http: panic serving 172.18.0.1:42200: runtime error: slice bounds out of range
goroutine 22 [running]:
net/http.(*conn).serve.func1(0xc00015e0a0)
	/usr/local/go/src/net/http/server.go:1746 +0xd0
panic(0x70d980, 0x9cf310)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/p4tin/goaws/app/gosqs.DeleteMessageBatch(0x7c75e0, 0xc000138620, 0xc000137c00)
	/go/src/github.com/p4tin/goaws/app/gosqs/gosqs.go:581 +0x150e
net/http.HandlerFunc.ServeHTTP(0x783760, 0x7c75e0, 0xc000138620, 0xc000137c00)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/p4tin/goaws/app/router.actionHandler(0x7c75e0, 0xc000138620, 0xc000137c00)
	/go/src/github.com/p4tin/goaws/app/router/router.go:62 +0xb6
net/http.HandlerFunc.ServeHTTP(0x7837c0, 0x7c75e0, 0xc000138620, 0xc000137c00)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/p4tin/goaws/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0xc0000572c0, 0x7c75e0, 0xc000138620, 0xc000137c00)
	/go/src/github.com/p4tin/goaws/vendor/github.com/gorilla/mux/mux.go:150 +0xf1
net/http.serverHandler.ServeHTTP(0xc000079d40, 0x7c75e0, 0xc000138620, 0xc000137a00)
	/usr/local/go/src/net/http/server.go:2741 +0xab
net/http.(*conn).serve(0xc00015e0a0, 0x7c78e0, 0xc000053380)
	/usr/local/go/src/net/http/server.go:1847 +0x646
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2851 +0x2f5
```

Basically what is happening,  first we iterate over messages with index `i` and when we delete we override the messages. But once we delete an element from messages the index `i` from the outer loop is already outdated and we can't rely on it.
The solution is to switch loops, iterate over `deleteEntries` first and then start looking for message to be deleted, so index `i` always will be actual.