### PR TITLE
MessageDeduplicationId support

### DIFF
--- a/app/common.go
+++ b/app/common.go
@@ -34,6 +34,7 @@ type Environment struct {
 	AccountID              string
 	LogToFile              bool
 	LogFile                string
+	EnableDuplicates       bool
 	Topics                 []EnvTopic
 	Queues                 []EnvQueue
 	QueueAttributeDefaults EnvQueueAttributes

--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -94,6 +95,8 @@ func LoadYamlConfig(filename string, env string) []string {
 			URL:                 queueUrl,
 			ReceiveWaitTimeSecs: queue.ReceiveMessageWaitTimeSeconds,
 			IsFIFO:              app.HasFIFOQueueName(queue.Name),
+			EnableDuplicates:    app.CurrentEnvironment.EnableDuplicates,
+			Duplicates:          make(map[string]time.Time),
 		}
 	}
 
@@ -156,6 +159,8 @@ func createSqsSubscription(configSubscription app.EnvSubsciption, topicArn strin
 			URL:                 queueUrl,
 			ReceiveWaitTimeSecs: app.CurrentEnvironment.QueueAttributeDefaults.ReceiveMessageWaitTimeSeconds,
 			IsFIFO:              app.HasFIFOQueueName(configSubscription.QueueName),
+			EnableDuplicates:    app.CurrentEnvironment.EnableDuplicates,
+			Duplicates:          make(map[string]time.Time),
 		}
 	}
 	qArn := app.SyncQueues.Queues[configSubscription.QueueName].Arn

--- a/app/conf/goaws.yaml
+++ b/app/conf/goaws.yaml
@@ -10,6 +10,7 @@ Local:                              # Environment name that can be passed on the
   AccountId: "100010001000"
   LogToFile: false                 # Log messages (true/false)
   LogFile: .st/goaws_messages.log  # Log filename (for message logging
+  EnableDuplicates: false           # Enable or not deduplication based on messageDeduplicationId
   QueueAttributeDefaults:           # default attributes for all queues
     VisibilityTimeout: 30              # message visibility timeout
     ReceiveMessageWaitTimeSeconds: 0   # receive message max wait time


### PR DESCRIPTION
[MessageDeduplicationId](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html) support feature.
Any messages sent with the same message deduplication ID are accepted successfully but aren't delivered during the 5-minute deduplication interval.
It works on fifo queues only. For backward compatibility `EnableDuplicates` (`false` by default) added to goaws.yaml file.