### PR TITLE
Fix delete check of DeleteMessageBatch

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -597,7 +597,7 @@ func DeleteMessageBatch(w http.ResponseWriter, req *http.Request) {
 
 	notFoundEntries := make([]app.BatchResultErrorEntry, 0)
 	for _, deleteEntry := range deleteEntries {
-		if deleteEntry.Deleted == false {
+		if deleteEntry.Deleted {
 			notFoundEntries = append(notFoundEntries, app.BatchResultErrorEntry{
 				Code:        "1",
 				Id:          deleteEntry.Id,


### PR DESCRIPTION
Deleted entries should be not found but non-deleted entries should be found.
Found this bug when using with [shoryuken](https://github.com/phstc/shoryuken).