### PR TITLE
Enable redrive policy in config file

### DIFF
--- a/app/common.go
+++ b/app/common.go
@@ -15,6 +15,7 @@ type EnvTopic struct {
 type EnvQueue struct {
 	Name                          string
 	ReceiveMessageWaitTimeSeconds int
+	RedrivePolicy                 string
 }
 
 type EnvQueueAttributes struct {


### PR DESCRIPTION
Currently there is no support for putting a redrive policy in the config file, e.g.

```yaml
  Queues:
    - Name: failed-messages
    - Name: messages
      RedrivePolicy: '{"deadLetterTargetArn":"arn:aws:sqs:us-west-2:100010001000:failed-messages","maxReceiveCount":10}'
      VisibilityTimeout: 5
```

This adds support for it by pulling the redrive policy logic into a separate function and calling it when creating queues from the config.