### PR TITLE
Fix the health check

### DIFF
--- a/app/router/router.go
+++ b/app/router/router.go
@@ -18,11 +18,11 @@ func New() http.Handler {
 	r := mux.NewRouter()
 
 	r.HandleFunc("/", actionHandler).Methods("GET", "POST")
+	r.HandleFunc("/health", health).Methods("GET")
 	r.HandleFunc("/{account}", actionHandler).Methods("GET", "POST")
 	r.HandleFunc("/queue/{queueName}", actionHandler).Methods("GET", "POST")
 	r.HandleFunc("/{account}/{queueName}", actionHandler).Methods("GET", "POST")
 	r.HandleFunc("/SimpleNotificationService/{id}.pem", pemHandler).Methods("GET")
-	r.HandleFunc("/health", health).Methods("GET")
 
 	return r
 }


### PR DESCRIPTION
I want to configure the health check for goaws on Docker, but the `/health` path is not working because the `/{account}` path is matching the health check request.

```console
$ curl -vs http://127.0.0.1:4100/health
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 4100 (#0)
> GET /health HTTP/1.1
> Host: 127.0.0.1:4100
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 400 Bad Request
< Date: Sun, 14 Jul 2019 06:03:14 GMT
< Content-Length: 11
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host 127.0.0.1 left intact
Bad Request
```

This PR fixes the registration order of health path to make the health check working.

```console
$ curl -vs http://127.0.0.1:4100/health
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 4100 (#0)
> GET /health HTTP/1.1
> Host: 127.0.0.1:4100
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Sun, 14 Jul 2019 06:12:13 GMT
< Content-Length: 2
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host 127.0.0.1 left intact
OK
```
