### PR TITLE
Move ErrorResponse RequestId out of the Error element

### DIFF
--- a/app/common.go
+++ b/app/common.go
@@ -45,12 +45,12 @@ type ResponseMetadata struct {
 
 /*** Error Responses ***/
 type ErrorResult struct {
-	Type      string `xml:"Type,omitempty"`
-	Code      string `xml:"Code,omitempty"`
-	Message   string `xml:"Message,omitempty"`
-	RequestId string `xml:"RequestId,omitempty"`
+	Type    string `xml:"Type,omitempty"`
+	Code    string `xml:"Code,omitempty"`
+	Message string `xml:"Message,omitempty"`
 }
 
 type ErrorResponse struct {
-	Result ErrorResult `xml:"Error"`
+	Result    ErrorResult `xml:"Error"`
+	RequestId string      `xml:"RequestId"`
 }

--- a/app/gosns/gosns.go
+++ b/app/gosns/gosns.go
@@ -725,7 +725,10 @@ func extractMessageFromJSON(msg string, protocol string) (string, error) {
 
 func createErrorResponse(w http.ResponseWriter, req *http.Request, err string) {
 	er := app.SnsErrors[err]
-	respStruct := app.ErrorResponse{app.ErrorResult{Type: er.Type, Code: er.Code, Message: er.Message, RequestId: "00000000-0000-0000-0000-000000000000"}}
+	respStruct := app.ErrorResponse{
+		Result:    app.ErrorResult{Type: er.Type, Code: er.Code, Message: er.Message},
+		RequestId: "00000000-0000-0000-0000-000000000000",
+	}
 
 	w.WriteHeader(er.HttpError)
 	enc := xml.NewEncoder(w)

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -892,7 +892,10 @@ func getQueueFromPath(formVal string, theUrl string) string {
 
 func createErrorResponse(w http.ResponseWriter, req *http.Request, err string) {
 	er := app.SqsErrors[err]
-	respStruct := app.ErrorResponse{app.ErrorResult{Type: er.Type, Code: er.Code, Message: er.Message, RequestId: "00000000-0000-0000-0000-000000000000"}}
+	respStruct := app.ErrorResponse{
+		Result:    app.ErrorResult{Type: er.Type, Code: er.Code, Message: er.Message},
+		RequestId: "00000000-0000-0000-0000-000000000000",
+	}
 
 	w.WriteHeader(er.HttpError)
 	enc := xml.NewEncoder(w)


### PR DESCRIPTION
While working with an overly strict client library, I ran across a minor bug in goaws's ErrorResponse. According to the docs (link below), the `RequestId` element should be a sibling of `Error`, but goaws puts it inside. This patch should fix it. I apologize for not adding any tests, my Go knowledge is a bit too limited for that.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-api-responses.html