### PR TITLE
Fix panic for concurrent DeleteQueue & ReceiveMessage

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -374,15 +374,13 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 	for loops > 0 {
 		app.SyncQueues.RLock()
 		_, queueFound := app.SyncQueues.Queues[queueName]
-		var messageFound bool
-		if queueFound {
-			messageFound = len(app.SyncQueues.Queues[queueName].Messages)-numberOfHiddenMessagesInQueue(*app.SyncQueues.Queues[queueName]) != 0
-		}
-		app.SyncQueues.RUnlock()
 		if !queueFound {
+			app.SyncQueues.RUnlock()
 			createErrorResponse(w, req, "QueueNotFound")
 			return
 		}
+		messageFound := len(app.SyncQueues.Queues[queueName].Messages)-numberOfHiddenMessagesInQueue(*app.SyncQueues.Queues[queueName]) != 0
+		app.SyncQueues.RUnlock()
 		if !messageFound {
 			time.Sleep(100 * time.Millisecond)
 			loops--


### PR DESCRIPTION
Hi @p4tin,

Hope we can merge the below bug fix, thanks!

Fixes panic at  goaws/app/gosqs/gosqs.go:376. use case `DeleteQueue()` while something is still blocked by `ReceiveMessage()`

Fixes the below panic in `ReceiveMessage`
```[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x12bf1a0]

goroutine 50 [running]:
github.com/sebcante/goaws/app/gosqs.ReceiveMessage(0x13fe060, 0xc000088ac0, 0xc0001ce800)
        github.com/sebcante/goaws/app/gosqs/gosqs.go:376 +0x410
net/http.HandlerFunc.ServeHTTP(...)
        /Users/seb/ap/bin/gobin/go/src/net/http/server.go:1995
github.com/sebcante/goaws/app/gosqs.TestReceiveMessage_WithConcurrentDeleteQueue.func1(0xc000018b20, 0xc000163c00)
        github.com/sebcante/goaws/app/gosqs/gosqs_test.go:1081 +0x344
created by github.com/sebcante/goaws/app/gosqs.TestReceiveMessage_WithConcurrentDeleteQueue
        github.com/sebcante/goaws/app/gosqs/gosqs_test.go:1065 +0x482"
```