### PR TITLE
Several minor fixes & enhancements to GoSNS

### DIFF
--- a/app/gosns/gosns_test.go
+++ b/app/gosns/gosns_test.go
@@ -1,13 +1,14 @@
 package gosns
 
 import (
-	"github.com/gorilla/mux"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/mux"
 
 	"github.com/p4tin/goaws/app"
 	"github.com/p4tin/goaws/app/common"
@@ -470,6 +471,17 @@ func TestGetSubscriptionAttributesHandler_POST_Success(t *testing.T) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)
 	}
+
+	expectedElements := []string{"Owner", "RawMessageDelivery", "TopicArn", "Endpoint", "PendingConfirmation",
+		"ConfirmationWasAuthenticated", "SubscriptionArn", "Protocol", "FilterPolicy"}
+	for _, element := range expectedElements {
+		expected := "<key>" + element + "</key>"
+		if !strings.Contains(rr.Body.String(), expected) {
+			t.Errorf("handler returned unexpected body: got %v want %v",
+				rr.Body.String(), expected)
+		}
+	}
+
 	// Check the response body is what we expect.
 	expected = "{&#34;foo&#34;:[&#34;bar&#34;]}"
 	if !strings.Contains(rr.Body.String(), expected) {


### PR DESCRIPTION
* Use the configured account ID instead of `000000000000` in topic ARNs 
* Add support for `RawMessageDelivery` & `FilterPolicy` to the `Subscribe` action
* Add more attributes to `GetSubscriptionAttributes` response to bring in line with the AWS response

If you'd prefer these split out into separate atomic PRs, let me know and I'll resubmit.