### PR TITLE
Fix the GoSQS response to DeleteQueue

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -696,7 +696,7 @@ func DeleteQueue(w http.ResponseWriter, req *http.Request) {
 	app.SyncQueues.Unlock()
 
 	// Create, encode/xml and send response
-	respStruct := app.DeleteMessageResponse{"http://queue.amazonaws.com/doc/2012-11-05/", app.ResponseMetadata{RequestId: "00000000-0000-0000-0000-000000000000"}}
+	respStruct := app.DeleteQueueResponse{"http://queue.amazonaws.com/doc/2012-11-05/", app.ResponseMetadata{RequestId: "00000000-0000-0000-0000-000000000000"}}
 	enc := xml.NewEncoder(w)
 	enc.Indent("  ", "    ")
 	if err := enc.Encode(respStruct); err != nil {

--- a/app/sqs_messages.go
+++ b/app/sqs_messages.go
@@ -86,6 +86,11 @@ type DeleteMessageResponse struct {
 	Metadata ResponseMetadata `xml:"ResponseMetadata,omitempty"`
 }
 
+type DeleteQueueResponse struct {
+	Xmlns    string           `xml:"xmlns,attr,omitempty"`
+	Metadata ResponseMetadata `xml:"ResponseMetadata,omitempty"`
+}
+
 type DeleteMessageBatchResultEntry struct {
 	Id string `xml:"Id"`
 }


### PR DESCRIPTION
* Use `DeleteQueueResponse` instead of `DeleteMessageResponse` when deleting queue