### PR TITLE
Fix sqs Receive Attributes to be millis

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -9,11 +9,10 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/gorilla/mux"
 	"github.com/p4tin/goaws/app"
 	"github.com/p4tin/goaws/app/common"
+	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -860,10 +859,10 @@ func getMessageResult(m *app.Message) *app.ResultMessage {
 	}
 
 	attrsMap := map[string]string{
-		"ApproximateFirstReceiveTimestamp": fmt.Sprintf("%d", m.ReceiptTime.Unix()),
+		"ApproximateFirstReceiveTimestamp": fmt.Sprintf("%d", m.ReceiptTime.UnixNano()/int64(time.Millisecond)),
 		"SenderId":                         app.CurrentEnvironment.AccountID,
 		"ApproximateReceiveCount":          fmt.Sprintf("%d", m.NumberOfReceives+1),
-		"SentTimestamp":                    fmt.Sprintf("%d", time.Now().UTC().Unix()),
+		"SentTimestamp":                    fmt.Sprintf("%d", time.Now().UTC().UnixNano()/int64(time.Millisecond)),
 	}
 
 	var attrs []*app.ResultAttribute

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/gorilla/mux"
 	"github.com/p4tin/goaws/app"
 	"github.com/p4tin/goaws/app/common"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {


### PR DESCRIPTION
changed ApproximateFirstReceiveTimestamp and SentTimestamp to be returned in millis as per doco https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html