### PR TITLE
Get resource url from host header

### DIFF
--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -67,19 +67,12 @@ func LoadYamlConfig(filename string, env string) []string {
 		app.CurrentEnvironment.AccountID = "queue"
 	}
 
-	if app.CurrentEnvironment.Host == "" {
-		app.CurrentEnvironment.Host = "localhost"
-		app.CurrentEnvironment.Port = "4100"
-	}
-
 	app.SyncQueues.Lock()
 	app.SyncTopics.Lock()
 	for _, queue := range envs[env].Queues {
-		queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port +
-			"/" + app.CurrentEnvironment.AccountID + "/" + queue.Name
+		queueUrl := "http://%s/" + app.CurrentEnvironment.AccountID + "/" + queue.Name
 		if app.CurrentEnvironment.Region != "" {
-			queueUrl = "http://" + app.CurrentEnvironment.Region + "." + app.CurrentEnvironment.Host + ":" +
-				app.CurrentEnvironment.Port + "/" + app.CurrentEnvironment.AccountID + "/" + queue.Name
+			queueUrl = "http://" + app.CurrentEnvironment.Region + ".%s/" + app.CurrentEnvironment.AccountID + "/" + queue.Name
 		}
 		queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":" + app.CurrentEnvironment.AccountID + ":" + queue.Name
 
@@ -142,11 +135,9 @@ func createHttpSubscription(configSubscription app.EnvSubsciption) *app.Subscrip
 
 func createSqsSubscription(configSubscription app.EnvSubsciption, topicArn string) *app.Subscription {
 	if _, ok := app.SyncQueues.Queues[configSubscription.QueueName]; !ok {
-		queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port +
-			"/" + app.CurrentEnvironment.AccountID + "/" + configSubscription.QueueName
+		queueUrl := "http://%s/" + app.CurrentEnvironment.AccountID + "/" + configSubscription.QueueName
 		if app.CurrentEnvironment.Region != "" {
-			queueUrl = "http://" + app.CurrentEnvironment.Region + "." + app.CurrentEnvironment.Host + ":" +
-				app.CurrentEnvironment.Port + "/" + app.CurrentEnvironment.AccountID + "/" + configSubscription.QueueName
+			queueUrl = "http://" + app.CurrentEnvironment.Region + ".%s/" + app.CurrentEnvironment.AccountID + "/" + configSubscription.QueueName
 		}
 		queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":" + app.CurrentEnvironment.AccountID + ":" + configSubscription.QueueName
 		app.SyncQueues.Queues[configSubscription.QueueName] = &app.Queue{

--- a/app/gosns/gosns_create_message_test.go
+++ b/app/gosns/gosns_create_message_test.go
@@ -19,6 +19,7 @@ const (
 func TestCreateMessageBody_NonJson(t *testing.T) {
 	message := "message text"
 	subject := "subject"
+	host := "localhost:4100"
 	subs := &app.Subscription{
 		Protocol:        "sqs",
 		TopicArn:        "topic-arn",
@@ -26,7 +27,7 @@ func TestCreateMessageBody_NonJson(t *testing.T) {
 		Raw:             false,
 	}
 
-	snsMessage, err := CreateMessageBody(subs, message, subject, messageStructureEmpty, make(map[string]app.MessageAttributeValue))
+	snsMessage, err := CreateMessageBody(host, subs, message, subject, messageStructureEmpty, make(map[string]app.MessageAttributeValue))
 	if err != nil {
 		t.Fatalf(`error creating SNS message: %s`, err)
 	}
@@ -67,8 +68,9 @@ func TestCreateMessageBody_OnlyDefaultValueInJson(t *testing.T) {
 	}
 	message := `{"default": "default message text", "http": "HTTP message text"}`
 	subject := "subject"
+	host := "localhost:4100"
 
-	snsMessage, err := CreateMessageBody(subs, message, subject, messageStructureJSON, nil)
+	snsMessage, err := CreateMessageBody(host, subs, message, subject, messageStructureJSON, nil)
 	if err != nil {
 		t.Fatalf(`error creating SNS message: %s`, err)
 	}
@@ -110,8 +112,9 @@ func TestCreateMessageBody_OnlySqsValueInJson(t *testing.T) {
 	}
 	message := `{"sqs": "message text"}`
 	subject := "subject"
+	host := "localhost:4100"
 
-	snsMessage, err := CreateMessageBody(subs, message, subject, messageStructureJSON, nil)
+	snsMessage, err := CreateMessageBody(host, subs, message, subject, messageStructureJSON, nil)
 	if err == nil {
 		t.Fatalf(`error expected but instead SNS message was returned: %s`, snsMessage)
 	}
@@ -128,8 +131,9 @@ func TestCreateMessageBody_BothDefaultAndSqsValuesInJson(t *testing.T) {
 	}
 	message := `{"default": "default message text", "sqs": "sqs message text"}`
 	subject := "subject"
+	host := "localhost:4100"
 
-	snsMessage, err := CreateMessageBody(subs, message, subject, messageStructureJSON, nil)
+	snsMessage, err := CreateMessageBody(host, subs, message, subject, messageStructureJSON, nil)
 	if err != nil {
 		t.Fatalf(`error creating SNS message: %s`, err)
 	}
@@ -171,8 +175,9 @@ func TestCreateMessageBody_NonJsonContainingJson(t *testing.T) {
 	}
 	message := `{"default": "default message text", "sqs": "sqs message text"}`
 	subject := "subject"
+	host := "localhost:4100"
 
-	snsMessage, err := CreateMessageBody(subs, message, subject, "", nil)
+	snsMessage, err := CreateMessageBody(host, subs, message, subject, "", nil)
 	if err != nil {
 		t.Fatalf(`error creating SNS message: %s`, err)
 	}

--- a/app/gosns/gosns_test.go
+++ b/app/gosns/gosns_test.go
@@ -124,7 +124,7 @@ func TestPublishHandler_POST_FilterPolicyRejectsTheMessage(t *testing.T) {
 
 	// We set up queue so later we can check if anything was posted there
 	queueName := "testingQueue"
-	queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port + "/queue/" + queueName
+	queueUrl := "http://" + req.Host + "/queue/" + queueName
 	queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":000000000000:" + queueName
 	app.SyncQueues.Queues[queueName] = &app.Queue{
 		Name:        queueName,
@@ -195,7 +195,7 @@ func TestPublishHandler_POST_FilterPolicyPassesTheMessage(t *testing.T) {
 
 	// We set up queue so later we can check if anything was posted there
 	queueName := "testingQueue"
-	queueUrl := "http://" + app.CurrentEnvironment.Host + ":" + app.CurrentEnvironment.Port + "/queue/" + queueName
+	queueUrl := "http://" + req.Host + "/queue/" + queueName
 	queueArn := "arn:aws:sqs:" + app.CurrentEnvironment.Region + ":000000000000:" + queueName
 	app.SyncQueues.Queues[queueName] = &app.Queue{
 		Name:        queueName,

--- a/app/gosqs/gosqs_test.go
+++ b/app/gosqs/gosqs_test.go
@@ -54,9 +54,9 @@ func TestListQueues_POST_Success(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(ListQueues)
 
-	app.SyncQueues.Queues["foo"] = &app.Queue{Name: "foo", URL: "http://:/queue/foo"}
-	app.SyncQueues.Queues["bar"] = &app.Queue{Name: "bar", URL: "http://:/queue/bar"}
-	app.SyncQueues.Queues["foobar"] = &app.Queue{Name: "foobar", URL: "http://:/queue/foobar"}
+	app.SyncQueues.Queues["foo"] = &app.Queue{Name: "foo", URL: "http://%s/queue/foo"}
+	app.SyncQueues.Queues["bar"] = &app.Queue{Name: "bar", URL: "http://%s/queue/bar"}
+	app.SyncQueues.Queues["foobar"] = &app.Queue{Name: "foobar", URL: "http://%s/queue/foobar"}
 
 	handler.ServeHTTP(rr, req)
 
@@ -66,7 +66,7 @@ func TestListQueues_POST_Success(t *testing.T) {
 	}
 
 	// Check the response body is what we expect.
-	expected := "<QueueUrl>http://:/queue/bar</QueueUrl>"
+	expected := "<QueueUrl>http:///queue/bar</QueueUrl>"
 	if !strings.Contains(rr.Body.String(), expected) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)
@@ -86,7 +86,7 @@ func TestListQueues_POST_Success(t *testing.T) {
 	}
 
 	// Check the response body is what we expect.
-	unexpected := "<QueueUrl>http://:/queue/bar</QueueUrl>"
+	unexpected := "<QueueUrl>http:///queue/bar</QueueUrl>"
 	if strings.Contains(rr.Body.String(), unexpected) {
 		t.Errorf("handler returned unexpected body: got %v",
 			rr.Body.String())
@@ -132,7 +132,7 @@ func TestCreateQueuehandler_POST_CreateQueue(t *testing.T) {
 	}
 	expectedQueue := &app.Queue{
 		Name:        queueName,
-		URL:         "http://://" + queueName,
+		URL:         "http://%s//" + queueName,
 		Arn:         "arn:aws:sqs:::" + queueName,
 		TimeoutSecs: 60,
 	}
@@ -178,7 +178,7 @@ func TestCreateFIFOQueuehandler_POST_CreateQueue(t *testing.T) {
 	}
 	expectedQueue := &app.Queue{
 		Name:        queueName,
-		URL:         "http://://" + queueName,
+		URL:         "http://%s//" + queueName,
 		Arn:         "arn:aws:sqs:::" + queueName,
 		TimeoutSecs: 60,
 		IsFIFO:      true,


### PR DESCRIPTION
Hi @p4tin 
First of all want to thank you for your project, it's really helpful.
I'm trying to spin up goaws using docker-compose with dynamic host port mapping and I had problems trying to send a message to URL that was retrieved from GetQueueUrl, cause queue url host and port are based on configuration file instead of HTTP Host header value. Also it's hard to query goaws instance from host and overlay networks at the same time.
I've submitted this PR with a resolution of this problem. 