### PR TITLE
fix routes order

### DIFF
--- a/app/router/router.go
+++ b/app/router/router.go
@@ -21,8 +21,8 @@ func New() http.Handler {
 	r.HandleFunc("/health", health).Methods("GET")
 	r.HandleFunc("/{account}", actionHandler).Methods("GET", "POST")
 	r.HandleFunc("/queue/{queueName}", actionHandler).Methods("GET", "POST")
-	r.HandleFunc("/{account}/{queueName}", actionHandler).Methods("GET", "POST")
 	r.HandleFunc("/SimpleNotificationService/{id}.pem", pemHandler).Methods("GET")
+	r.HandleFunc("/{account}/{queueName}", actionHandler).Methods("GET", "POST")
 
 	return r
 }

--- a/app/router/router_test.go
+++ b/app/router/router_test.go
@@ -90,3 +90,19 @@ func TestIndexServerhandler_POST_GoodRequest_With_URL(t *testing.T) {
 			status, http.StatusOK)
 	}
 }
+
+func TestIndexServerhandler_GET_GoodRequest_Pem_cert(t *testing.T) {
+
+	req, err := http.NewRequest("GET", "/SimpleNotificationService/100010001000.pem", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	New().ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+}


### PR DESCRIPTION
Requests to `SigningCertURL` are currently handled by `actionHandler` instead of `pemHandler` because of wrong routes order. This PR fix this issue.