### PR TITLE
fix router order

### DIFF
--- a/app/router/router.go
+++ b/app/router/router.go
@@ -17,11 +17,11 @@ import (
 func New() http.Handler {
 	r := mux.NewRouter()
 
+	r.HandleFunc("/SimpleNotificationService/{id}.pem", pemHandler).Methods("GET")
 	r.HandleFunc("/", actionHandler).Methods("GET", "POST")
 	r.HandleFunc("/health", health).Methods("GET")
 	r.HandleFunc("/{account}", actionHandler).Methods("GET", "POST")
 	r.HandleFunc("/queue/{queueName}", actionHandler).Methods("GET", "POST")
-	r.HandleFunc("/SimpleNotificationService/{id}.pem", pemHandler).Methods("GET")
 	r.HandleFunc("/{account}/{queueName}", actionHandler).Methods("GET", "POST")
 
 	return r


### PR DESCRIPTION
`SimpleNotificationService/{id}.pem` endpoint was falling into `/` path causing the consumer to receive a Bad Request response.