### PR TITLE
Respect GetQueueAttributes AttributeName parameters

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -774,6 +774,27 @@ func GetQueueAttributes(w http.ResponseWriter, req *http.Request) {
 	// Retrieve FormValues required
 	queueUrl := getQueueFromPath(req.FormValue("QueueUrl"), req.URL.String())
 
+	attribute_names := map[string]bool {}
+
+	for field, value := range req.Form {
+		if strings.HasPrefix(field, "AttributeName.") {
+			attribute_names[value[0]] = true
+		}
+	}
+
+	include_attr := func(a string) bool {
+		if len(attribute_names) == 0 {
+			return true
+		}
+		if _, ok := attribute_names[a]; ok {
+			return true
+		}
+		if _, ok := attribute_names["All"]; ok {
+			return true
+		}
+		return false
+	}
+	
 	queueName := ""
 	if queueUrl == "" {
 		vars := mux.Vars(req)
@@ -788,31 +809,47 @@ func GetQueueAttributes(w http.ResponseWriter, req *http.Request) {
 	if queue, ok := app.SyncQueues.Queues[queueName]; ok {
 		// Create, encode/xml and send response
 		attribs := make([]app.Attribute, 0, 0)
-		attr := app.Attribute{Name: "VisibilityTimeout", Value: strconv.Itoa(queue.TimeoutSecs)}
-		attribs = append(attribs, attr)
-		attr = app.Attribute{Name: "DelaySeconds", Value: "0"}
-		attribs = append(attribs, attr)
-		attr = app.Attribute{Name: "ReceiveMessageWaitTimeSeconds", Value: strconv.Itoa(queue.ReceiveWaitTimeSecs)}
-		attribs = append(attribs, attr)
-		attr = app.Attribute{Name: "ApproximateNumberOfMessages", Value: strconv.Itoa(len(queue.Messages))}
-		attribs = append(attribs, attr)
-		app.SyncQueues.RLock()
-		attr = app.Attribute{Name: "ApproximateNumberOfMessagesNotVisible", Value: strconv.Itoa(numberOfHiddenMessagesInQueue(*queue))}
-		app.SyncQueues.RUnlock()
-		attribs = append(attribs, attr)
-		attr = app.Attribute{Name: "CreatedTimestamp", Value: "0000000000"}
-		attribs = append(attribs, attr)
-		attr = app.Attribute{Name: "LastModifiedTimestamp", Value: "0000000000"}
-		attribs = append(attribs, attr)
-		attr = app.Attribute{Name: "QueueArn", Value: queue.Arn}
-		attribs = append(attribs, attr)
+		if include_attr("VisibilityTimeout") {
+			attr := app.Attribute{Name: "VisibilityTimeout", Value: strconv.Itoa(queue.TimeoutSecs)}
+			attribs = append(attribs, attr)
+		}
+		if include_attr("DelaySeconds") {
+			attr := app.Attribute{Name: "DelaySeconds", Value: "0"}
+			attribs = append(attribs, attr)
+		}
+		if include_attr("ReceiveMessageWaitTimeSeconds") {
+			attr := app.Attribute{Name: "ReceiveMessageWaitTimeSeconds", Value: strconv.Itoa(queue.ReceiveWaitTimeSecs)}
+			attribs = append(attribs, attr)
+		}
+		if include_attr("ApproximateNumberOfMessages") {
+			attr := app.Attribute{Name: "ApproximateNumberOfMessages", Value: strconv.Itoa(len(queue.Messages))}
+			attribs = append(attribs, attr)
+		}
+		if include_attr("ApproximateNumberOfMessagesNotVisible") {
+			attr := app.Attribute{Name: "ApproximateNumberOfMessagesNotVisible", Value: strconv.Itoa(numberOfHiddenMessagesInQueue(*queue))}
+			attribs = append(attribs, attr)
+		}
+		if include_attr("CreatedTimestamp") {
+			attr := app.Attribute{Name: "CreatedTimestamp", Value: "0000000000"}
+			attribs = append(attribs, attr)
+		}
+		if include_attr("LastModifiedTimestamp") {
+			attr := app.Attribute{Name: "LastModifiedTimestamp", Value: "0000000000"}
+			attribs = append(attribs, attr)
+		}
+		if include_attr("QueueArn") {
+			attr := app.Attribute{Name: "QueueArn", Value: queue.Arn}
+			attribs = append(attribs, attr)
+		}
 
 		deadLetterTargetArn := ""
 		if queue.DeadLetterQueue != nil {
 			deadLetterTargetArn = queue.DeadLetterQueue.Name
 		}
-		attr = app.Attribute{Name: "RedrivePolicy", Value: fmt.Sprintf(`{"maxReceiveCount": "%d", "deadLetterTargetArn":"%s"}`, queue.MaxReceiveCount, deadLetterTargetArn)}
-		attribs = append(attribs, attr)
+		if include_attr("RedrivePolicy") {
+			attr := app.Attribute{Name: "RedrivePolicy", Value: fmt.Sprintf(`{"maxReceiveCount": "%d", "deadLetterTargetArn":"%s"}`, queue.MaxReceiveCount, deadLetterTargetArn)}
+			attribs = append(attribs, attr)
+		}
 
 		result := app.GetQueueAttributesResult{Attrs: attribs}
 		respStruct := app.GetQueueAttributesResponse{"http://queue.amazonaws.com/doc/2012-11-05/", result, app.ResponseMetadata{RequestId: "00000000-0000-0000-0000-000000000000"}}


### PR DESCRIPTION
This PR allows `goawssqs` to respect the [GetQueueAttributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html) `AtrributeName.N` parameter and only return requested attributes. It also removes a redundant `app.SyncQueues.RLock()` call that was causing the SQS handler to lock up indefinitely when bombarded with `GetQueueAttributes` calls.