### PR TITLE
Fix message decoding

### DIFF
--- a/app/gosns/gosns.go
+++ b/app/gosns/gosns.go
@@ -553,7 +553,12 @@ func publishSQS(w http.ResponseWriter, req *http.Request,
 		} else {
 			msg.MessageAttributes = messageAttributes
 			msg.MD5OfMessageAttributes = common.HashAttributes(messageAttributes)
-			msg.MessageBody = []byte(messageBody)
+			m, err := extractMessageFromJSON(messageBody, subs.Protocol)
+			if (err == nil) {
+				msg.MessageBody = []byte(m)
+			} else {
+				msg.MessageBody = []byte(messageBody)
+			}
 		}
 
 		msg.MD5OfMessageBody = common.GetMD5Hash(messageBody)


### PR DESCRIPTION
In situation when subscribe a queue to an SNS topic with `RawMessageDelivery` option set up and we push encoded JSON
```
{\"default\": \"{\\\"test\\\": \\\"xxxx\\\"}\"}
```

The message is forwarded and contains protocol:
```
{
    "Messages": [
        {
            "MessageId": "b6e8402a-2798-405c-9955-78c10061610a",
            "ReceiptHandle": "b6e8402a-2798-405c-9955-78c10061610a#cbcbd29e-f9a8-4321-b3b0-3f5631ff1a8b",
            "MD5OfBody": "7b2d325f1dac7c79cf89e1fcde3b2e1d",
            "Body": "{\"default\": \"{\\\"test\\\": \\\"xxxx\\\"}\"}",
            "Attributes": {
                "ApproximateFirstReceiveTimestamp": "1601971148229",
                "SenderId": "1601971148229",
                "ApproximateReceiveCount": "1",
                "SentTimestamp": "1601971148229"
            },
            "MD5OfMessageAttributes": "d41d8cd98f00b204e9800998ecf8427e"
        }
    ]
}
```

AWS in `receive-message` don't show the protocol of message but only message.

Expected result:
```
{
    "Messages": [
        {
            "MessageId": "b6e8402a-2798-405c-9955-78c10061610a",
            "ReceiptHandle": "b6e8402a-2798-405c-9955-78c10061610a#cbcbd29e-f9a8-4321-b3b0-3f5631ff1a8b",
            "MD5OfBody": "7b2d325f1dac7c79cf89e1fcde3b2e1d",
            "Body": "{\"test\": \"xxxx\"}",
            "Attributes": {
                "ApproximateFirstReceiveTimestamp": "1601971148229",
                "SenderId": "1601971148229",
                "ApproximateReceiveCount": "1",
                "SentTimestamp": "1601971148229"
            },
            "MD5OfMessageAttributes": "d41d8cd98f00b204e9800998ecf8427e"
        }
    ]
}
```