### PR TITLE
app/gosqs: increment number of receives for a message

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -180,8 +180,8 @@ func SendMessage(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if (app.SyncQueues.Queues[queueName].MaximumMessageSize > 0 &&
-		len(messageBody) > app.SyncQueues.Queues[queueName].MaximumMessageSize) {
+	if app.SyncQueues.Queues[queueName].MaximumMessageSize > 0 &&
+		len(messageBody) > app.SyncQueues.Queues[queueName].MaximumMessageSize {
 		// Message size is too big
 		createErrorResponse(w, req, "MessageTooBig")
 		return
@@ -465,6 +465,7 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 			msg.ReceiptHandle = msg.Uuid + "#" + uuid
 			msg.ReceiptTime = time.Now().UTC()
 			msg.VisibilityTimeout = time.Now().Add(time.Duration(app.SyncQueues.Queues[queueName].TimeoutSecs) * time.Second)
+			msg.NumberOfReceives++
 
 			if app.SyncQueues.Queues[queueName].IsFIFO {
 				// If we got messages here it means we have not processed it yet, so get next
@@ -920,7 +921,7 @@ func getMessageResult(m *app.Message) *app.ResultMessage {
 	attrsMap := map[string]string{
 		"ApproximateFirstReceiveTimestamp": fmt.Sprintf("%d", m.ReceiptTime.UnixNano()/int64(time.Millisecond)),
 		"SenderId":                         app.CurrentEnvironment.AccountID,
-		"ApproximateReceiveCount":          fmt.Sprintf("%d", m.NumberOfReceives+1),
+		"ApproximateReceiveCount":          fmt.Sprintf("%d", m.NumberOfReceives),
 		"SentTimestamp":                    fmt.Sprintf("%d", time.Now().UTC().UnixNano()/int64(time.Millisecond)),
 	}
 


### PR DESCRIPTION
When returning an SQS message, increment the 'NumberOfReceives' so it
always contains the number of times a message has been received but not
yet deleted.

From the AWS SQS docs:

    ApproximateReceiveCount – Returns the number of times a message has been received across all queues but not deleted.