### PR TITLE
Fix data structure and tag name of ListSubscriptionsByTopicResult

### DIFF
--- a/app/sns_messages.go
+++ b/app/sns_messages.go
@@ -106,9 +106,9 @@ type ListSubscriptionsByTopicResult struct {
 }
 
 type ListSubscriptionsByTopicResponse struct {
-	Xmlns    string                  `xml:"xmlns,attr"`
-	Result   ListSubscriptionsResult `xml:"ListSubscriptionsResult"`
-	Metadata ResponseMetadata        `xml:"ResponseMetadata"`
+	Xmlns    string                         `xml:"xmlns,attr"`
+	Result   ListSubscriptionsByTopicResult `xml:"ListSubscriptionsByTopicResult"`
+	Metadata ResponseMetadata               `xml:"ResponseMetadata"`
 }
 
 /*** Publish ***/


### PR DESCRIPTION
This was returning `<ListSubscriptionsResult>` in the payload, causing the AWS CLI to parse the response incorrectly.

Before:

    aws --endpoint-url http://localhost:4100 sns list-subscriptions-by-topic --topic-arn="arn:aws:sns:us-east-1:100010001000:local-topic1"

    'ListSubscriptionsByTopicResult'

After:

    aws --endpoint-url http://localhost:4100 sns list-subscriptions-by-topic --topic-arn="arn:aws:sns:us-east-1:100010001000:local-topic1"
    {
        "Subscriptions": [
            {
                "SubscriptionArn": "arn:aws:sns:us-east-1:100010001000:local-topic1:613f2fe9-6a92-4bef-8d9a-3a6bca845a0f",
                "Owner": "",
                "Protocol": "sqs",
                "Endpoint": "arn:aws:sqs:us-east-1:100010001000:local-queue3",
                "TopicArn": "arn:aws:sns:us-east-1:100010001000:local-topic1"
            },
            {
                "SubscriptionArn": "arn:aws:sns:us-east-1:100010001000:local-topic1:99599561-1a71-415f-bbad-af30b14718f1",
                "Owner": "",
                "Protocol": "sqs",
                "Endpoint": "arn:aws:sqs:us-east-1:100010001000:local-queue4",
                "TopicArn": "arn:aws:sns:us-east-1:100010001000:local-topic1"
            }
        ]
    }